### PR TITLE
GUTTOK 14 - 구독 서비스 생성 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -1,10 +1,14 @@
 package com.app.guttokback.global.apiResponse;
 
 public class ResponseMessages {
+    // user
     public static final String USER_RETRIEVE_SUCCESS = "유저 상세 조회 성공";
     public static final String USER_SAVE_SUCCESS = "유저 저장 성공";
     public static final String PASSWORD_UPDATE_SUCCESS = "비밀번호 수정 성공";
     public static final String NICKNAME_UPDATE_SUCCESS = "닉네임 수정 성공";
     public static final String ALARM_UPDATE_SUCCESS = "알림 수정 성공";
     public static final String USER_DELETE_SUCCESS = "유저 삭제 성공";
+
+    // userSubscription
+    public static final String USER_SUBSCRIPTION_SAVE_SUCCESS = "구독항목 저장 성공";
 }

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -5,8 +5,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+    // user
     ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
     EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다"),
+
+    // subscription
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 서비스를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
-    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다");
+    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다"),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 서비스를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -1,0 +1,30 @@
+package com.app.guttokback.subscription.controller;
+
+import com.app.guttokback.global.apiResponse.ApiResponse;
+import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
+import com.app.guttokback.subscription.service.UserSubscriptionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_SUBSCRIPTION_SAVE_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/subscriptions")
+public class UserSubscriptionController {
+
+    private final UserSubscriptionService userSubscriptionService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Object>> userSubscriptionSave(
+            @Valid @RequestBody UserSubscriptionSaveRequest userSubscriptionSaveRequest
+    ) {
+        userSubscriptionService.save(userSubscriptionSaveRequest.toSave());
+        return ApiResponse.success(USER_SUBSCRIPTION_SAVE_SUCCESS);
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/domain/SubscriptionEntity.java
+++ b/src/main/java/com/app/guttokback/subscription/domain/SubscriptionEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,7 +17,6 @@ public class SubscriptionEntity extends AuditInformation {
     @Column(length = 50, nullable = false)
     private String name;
 
-    @Builder
     public SubscriptionEntity(String name) {
         this.name = name;
     }

--- a/src/main/java/com/app/guttokback/subscription/domain/SubscriptionEntity.java
+++ b/src/main/java/com/app/guttokback/subscription/domain/SubscriptionEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,4 +17,9 @@ public class SubscriptionEntity extends AuditInformation {
 
     @Column(length = 50, nullable = false)
     private String name;
+
+    @Builder
+    public SubscriptionEntity(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
+++ b/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
@@ -4,6 +4,7 @@ import com.app.guttokback.global.jpa.AuditInformation;
 import com.app.guttokback.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -59,4 +60,26 @@ public class UserSubscriptionEntity extends AuditInformation {
     @Comment("사용자 메모")
     private String memo;
 
+    @Builder
+    public UserSubscriptionEntity(UserEntity user,
+                                  String title,
+                                  SubscriptionEntity subscription,
+                                  long paymentAmount,
+                                  PaymentMethod paymentMethod,
+                                  LocalDate startDate,
+                                  PaymentCycle paymentCycle,
+                                  int paymentDay,
+                                  String memo
+    ) {
+        this.user = user;
+        this.title = title;
+        this.subscription = subscription;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = PaymentStatus.PENDING;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
@@ -7,12 +7,15 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSubscriptionSaveRequest {
 
     @NotNull(message = "회원 ID를 입력하세요.")
@@ -25,7 +28,6 @@ public class UserSubscriptionSaveRequest {
     @Positive(message = "구독 서비스 ID는 양수여야 합니다.")
     private Long subscriptionId;
 
-    @NotNull(message = "납부금액을 입력하세요.")
     @Positive(message = "납부금액은 양수여야 합니다.")
     private long paymentAmount;
 
@@ -33,31 +35,51 @@ public class UserSubscriptionSaveRequest {
     private PaymentMethod paymentMethod;
 
     @NotNull(message = "첫 납부 날짜를 입력하세요.")
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
 
-    @NotNull(message = "결제주기를 입력하세요.")
+    @NotNull(message = "결제주기를 선택하세요.")
     private PaymentCycle paymentCycle;
 
-    @NotNull(message = "결제일자를 입력하세요.")
     @Min(value = 1, message = "결제일자는 1 이상이어야 합니다.")
     @Max(value = 31, message = "결제일자는 31 이하이어야 합니다.")
     private int paymentDay;
 
     private String memo;
 
+    @Builder
+    public UserSubscriptionSaveRequest(Long userId,
+                                       String title,
+                                       Long subscriptionId,
+                                       long paymentAmount,
+                                       PaymentMethod paymentMethod,
+                                       LocalDate startDate,
+                                       PaymentCycle paymentCycle,
+                                       int paymentDay,
+                                       String memo
+    ) {
+        this.userId = userId;
+        this.title = title;
+        this.subscriptionId = subscriptionId;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
+
     public UserSubscriptionSaveInfo toSave() {
-        return new UserSubscriptionSaveInfo(
-                userId,
-                title,
-                subscriptionId,
-                paymentAmount,
-                paymentMethod,
-                startDate,
-                paymentCycle,
-                paymentDay,
-                memo
-        );
+        return UserSubscriptionSaveInfo.builder()
+                .userId(userId)
+                .title(title)
+                .subscriptionId(subscriptionId)
+                .paymentAmount(paymentAmount)
+                .paymentMethod(paymentMethod)
+                .startDate(startDate)
+                .paymentCycle(paymentCycle)
+                .paymentDay(paymentDay)
+                .memo(memo)
+                .build();
     }
 
 }

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
@@ -1,0 +1,63 @@
+package com.app.guttokback.subscription.dto.controllerDto.request;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class UserSubscriptionSaveRequest {
+
+    @NotNull(message = "회원 ID를 입력하세요.")
+    @Positive(message = "회원 ID는 양수여야 합니다.")
+    private Long userId;
+
+    private String title;
+
+    @NotNull(message = "구독 서비스 ID를 입력하세요.")
+    @Positive(message = "구독 서비스 ID는 양수여야 합니다.")
+    private Long subscriptionId;
+
+    @NotNull(message = "납부금액을 입력하세요.")
+    @Positive(message = "납부금액은 양수여야 합니다.")
+    private long paymentAmount;
+
+    @NotNull(message = "결제수단을 선택하세요.")
+    private PaymentMethod paymentMethod;
+
+    @NotNull(message = "첫 납부 날짜를 입력하세요.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @NotNull(message = "결제주기를 입력하세요.")
+    private PaymentCycle paymentCycle;
+
+    @NotNull(message = "결제일자를 입력하세요.")
+    @Min(value = 1, message = "결제일자는 1 이상이어야 합니다.")
+    @Max(value = 31, message = "결제일자는 31 이하이어야 합니다.")
+    private int paymentDay;
+
+    private String memo;
+
+    public UserSubscriptionSaveInfo toSave() {
+        return new UserSubscriptionSaveInfo(
+                userId,
+                title,
+                subscriptionId,
+                paymentAmount,
+                paymentMethod,
+                startDate,
+                paymentCycle,
+                paymentDay,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
@@ -2,31 +2,36 @@ package com.app.guttokback.subscription.dto.serviceDto;
 
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSubscriptionSaveInfo {
 
-    private final Long userId;
+    private Long userId;
 
-    private final String title;
-    
-    private final Long subscriptionId;
+    private String title;
 
-    private final long paymentAmount;
+    private Long subscriptionId;
 
-    private final PaymentMethod paymentMethod;
+    private long paymentAmount;
 
-    private final LocalDate startDate;
+    private PaymentMethod paymentMethod;
 
-    private final PaymentCycle paymentCycle;
+    private LocalDate startDate;
 
-    private final int paymentDay;
+    private PaymentCycle paymentCycle;
 
-    private final String memo;
+    private int paymentDay;
 
+    private String memo;
+
+    @Builder
     public UserSubscriptionSaveInfo(Long userId,
                                     String title,
                                     Long subscriptionId,

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
@@ -12,6 +12,7 @@ public class UserSubscriptionSaveInfo {
     private final Long userId;
 
     private final String title;
+    
     private final Long subscriptionId;
 
     private final long paymentAmount;

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
@@ -1,0 +1,49 @@
+package com.app.guttokback.subscription.dto.serviceDto;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class UserSubscriptionSaveInfo {
+
+    private final Long userId;
+
+    private final String title;
+    private final Long subscriptionId;
+
+    private final long paymentAmount;
+
+    private final PaymentMethod paymentMethod;
+
+    private final LocalDate startDate;
+
+    private final PaymentCycle paymentCycle;
+
+    private final int paymentDay;
+
+    private final String memo;
+
+    public UserSubscriptionSaveInfo(Long userId,
+                                    String title,
+                                    Long subscriptionId,
+                                    long paymentAmount,
+                                    PaymentMethod paymentMethod,
+                                    LocalDate startDate,
+                                    PaymentCycle paymentCycle,
+                                    int paymentDay,
+                                    String memo
+    ) {
+        this.userId = userId;
+        this.title = title;
+        this.subscriptionId = subscriptionId;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/app/guttokback/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.app.guttokback.subscription.repository;
+
+import com.app.guttokback.subscription.domain.SubscriptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<SubscriptionEntity, Long> {
+}

--- a/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.app.guttokback.subscription.repository;
+
+import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSubscriptionRepository extends JpaRepository<UserSubscriptionEntity, Long> {
+}

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -1,0 +1,45 @@
+package com.app.guttokback.subscription.service;
+
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.global.exception.ErrorCode;
+import com.app.guttokback.subscription.domain.SubscriptionEntity;
+import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.repository.SubscriptionRepository;
+import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSubscriptionService {
+
+    private final UserSubscriptionRepository userSubscriptionRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserService userService;
+
+    public void save(UserSubscriptionSaveInfo userSubscriptionSaveInfo) {
+        UserEntity user = userService.userFindById(userSubscriptionSaveInfo.getUserId());
+        SubscriptionEntity subscription = findSubscriptionById(userSubscriptionSaveInfo.getSubscriptionId());
+
+        userSubscriptionRepository.save(
+                UserSubscriptionEntity.builder()
+                        .user(user)
+                        .title(userSubscriptionSaveInfo.getTitle())
+                        .subscription(subscription)
+                        .paymentAmount(userSubscriptionSaveInfo.getPaymentAmount())
+                        .paymentMethod(userSubscriptionSaveInfo.getPaymentMethod())
+                        .startDate(userSubscriptionSaveInfo.getStartDate())
+                        .paymentCycle(userSubscriptionSaveInfo.getPaymentCycle())
+                        .paymentDay(userSubscriptionSaveInfo.getPaymentDay())
+                        .memo(userSubscriptionSaveInfo.getMemo())
+                        .build());
+    }
+
+    private SubscriptionEntity findSubscriptionById(Long subscriptionId) {
+        return subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new CustomApplicationException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequestTest.java
+++ b/src/test/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequestTest.java
@@ -1,0 +1,287 @@
+package com.app.guttokback.subscription.dto.controllerDto.request;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+class UserSubscriptionSaveRequestTest {
+
+    @Test
+    @DisplayName("회원 ID가 null 일 경우 예외가 발생한다.")
+    public void userIdIsNullValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(null)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("회원 ID를 입력하세요.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("회원 ID가 음수 일 경우 예외가 발생한다.")
+    public void userIdNegativeValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(-1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("회원 ID는 양수여야 합니다.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("구독 서비스 ID가 null 일 경우 예외가 발생한다.")
+    public void subscriptionIdIsNullValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(null)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("구독 서비스 ID를 입력하세요.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("구독 서비스 ID가 음수 일 경우 예외가 발생한다.")
+    public void subscriptionIdNegativeValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(-1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("구독 서비스 ID는 양수여야 합니다.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("납부금액이 음수 일 경우 예외가 발생한다.")
+    public void paymentAmountNegativeValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(-1)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("납부금액은 양수여야 합니다.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("결제수단이 null 일 경우 예외가 발생한다.")
+    public void paymentMethodIsNullValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(null)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("결제수단을 선택하세요.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("첫 납부 날짜가 null 일 경우 예외가 발생한다.")
+    public void startDateIsNullValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(null)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("첫 납부 날짜를 입력하세요.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("결제주기가 null 일 경우 예외가 발생한다.")
+    public void paymentCycleIsNullValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(null)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("결제주기를 선택하세요.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("결제일자가 1 미만일 경우 예외가 발생한다.")
+    public void paymentDayMinValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(0)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("결제일자는 1 이상이어야 합니다.")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("결제일자가 31을 초과할 경우 예외가 발생한다.")
+    public void paymentDayMaxValidationTest() {
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(32)
+                .memo("test")
+                .build();
+
+        // when
+        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
+
+        // then
+        Assertions.assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("결제일자는 31 이하이어야 합니다.")
+                .hasSize(1);
+    }
+
+}

--- a/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
@@ -1,0 +1,151 @@
+package com.app.guttokback.subscription.service;
+
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.SubscriptionEntity;
+import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.repository.SubscriptionRepository;
+import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class UserSubscriptionServiceTest {
+
+    @Autowired
+    private UserSubscriptionService userSubscriptionService;
+    @Autowired
+    private UserSubscriptionRepository userSubscriptionRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @AfterEach
+    public void clear() {
+        userSubscriptionRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        subscriptionRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("존재하는 회원이 구독항목 생성 시 구독항목이 정상적으로 저장된다.")
+    public void savedUserSubscriptionTest() {
+        // given
+        UserEntity user = UserEntity.builder()
+                .email("test@test.com")
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        UserEntity savedUser = userRepository.save(user);
+
+        SubscriptionEntity subscription = SubscriptionEntity.builder().name("test").build();
+        SubscriptionEntity savedSubscription = subscriptionRepository.save(subscription);
+
+        UserSubscriptionSaveInfo savedUserSubscription = UserSubscriptionSaveInfo.builder()
+                .userId(savedUser.getId())
+                .title("test")
+                .subscriptionId(savedSubscription.getId())
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        userSubscriptionService.save(savedUserSubscription);
+
+        // then
+        UserSubscriptionEntity userSubscription = userSubscriptionRepository.findAll().stream().findFirst().orElseThrow();
+        assertThat(userSubscription.getTitle()).isEqualTo("test");
+        assertThat(userSubscription.getPaymentAmount()).isEqualTo(10000);
+        assertThat(userSubscription.getPaymentMethod()).isEqualTo(PaymentMethod.CARD);
+        assertThat(userSubscription.getStartDate()).isEqualTo(LocalDate.parse("2024-12-27"));
+        assertThat(userSubscription.getPaymentCycle()).isEqualTo(PaymentCycle.MONTHLY);
+        assertThat(userSubscription.getPaymentDay()).isEqualTo(15);
+        assertThat(userSubscription.getMemo()).isEqualTo("test");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("존재하지 않는 회원이 구독항목 생성 시 예외가 발생한다.")
+    public void saveUserSubscriptionByValidateUserTest() {
+        // given
+        SubscriptionEntity subscription = SubscriptionEntity.builder().name("test").build();
+        SubscriptionEntity savedSubscription = subscriptionRepository.save(subscription);
+
+        UserSubscriptionSaveInfo savedUserSubscription = UserSubscriptionSaveInfo.builder()
+                .userId(-1L)
+                .title("test")
+                .subscriptionId(savedSubscription.getId())
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        CustomApplicationException exception = assertThrows(CustomApplicationException.class,
+                () -> userSubscriptionService.save(savedUserSubscription));
+
+        // then
+        Assertions.assertThat(exception)
+                .isInstanceOf(CustomApplicationException.class)
+                .hasMessage("회원을 찾을 수 없습니다");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("구독서비스가 존재하지 않을 경우 구독항목 생성 시 예외가 발생한다.")
+    public void saveUserSubscriptionByValidateSubscriptionTest() {
+        // given
+        UserEntity user = UserEntity.builder()
+                .email("test@test.com")
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        UserEntity savedUser = userRepository.save(user);
+
+        UserSubscriptionSaveInfo savedUserSubscription = UserSubscriptionSaveInfo.builder()
+                .userId(savedUser.getId())
+                .title("test")
+                .subscriptionId(-1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2024-12-27"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .memo("test")
+                .build();
+
+        // when
+        CustomApplicationException exception = assertThrows(CustomApplicationException.class,
+                () -> userSubscriptionService.save(savedUserSubscription));
+
+        // then
+        Assertions.assertThat(exception)
+                .isInstanceOf(CustomApplicationException.class)
+                .hasMessage("구독 서비스를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
@@ -55,7 +55,7 @@ class UserSubscriptionServiceTest {
                 .build();
         UserEntity savedUser = userRepository.save(user);
 
-        SubscriptionEntity subscription = SubscriptionEntity.builder().name("test").build();
+        SubscriptionEntity subscription = new SubscriptionEntity("test");
         SubscriptionEntity savedSubscription = subscriptionRepository.save(subscription);
 
         UserSubscriptionSaveInfo savedUserSubscription = UserSubscriptionSaveInfo.builder()
@@ -89,7 +89,7 @@ class UserSubscriptionServiceTest {
     @DisplayName("존재하지 않는 회원이 구독항목 생성 시 예외가 발생한다.")
     public void saveUserSubscriptionByValidateUserTest() {
         // given
-        SubscriptionEntity subscription = SubscriptionEntity.builder().name("test").build();
+        SubscriptionEntity subscription = new SubscriptionEntity("test");
         SubscriptionEntity savedSubscription = subscriptionRepository.save(subscription);
 
         UserSubscriptionSaveInfo savedUserSubscription = UserSubscriptionSaveInfo.builder()


### PR DESCRIPTION
- 예외 처리
  - 필수 값 미 입력 시
  - 구독 서비스 미 존재 시
  - 생성하고자 하는 회원 미 존재 시
  - 결제일자 Min 1, Max 31 외의 숫자 입력 시
  - 첫 납부 날짜 `LocalDate` 타입이 아닐 시 yyyy-MM-dd (하이픈 포함)
  - 회원 ID, 구독 서비스 ID, 납부 금액 음수일 시

- subscriptionId 1L = 직접 입력

- 결제 주기 PaymentCycle `Enum`
  - `YEARLY("연")`, `MONTHLY("월")`, `WEEKLY("주")`, `DAILY("일")`;
- 결제 방법 PaymentMethod `Enum`
  - `CARD("카드")`, `BANK_TRANSFER("계좌이체")`
- 결제 상태 PaymentStatus `Enum`
  - `COMPLETED("결제 완료")`, `PENDING("미결제")`

- RequestBody
```json
{
    "userId": 1,
    "title": "",
    "subscriptionId": 1,
    "paymentAmount": 10000,
    "paymentMethod": "BANK_TRANSFER",
    "startDate": "2024-12-27",
    "paymentCycle": "MONTHLY",
    "paymentDay": 15,
    "memo": ""
}
```

- ResponseBody
```json
{
    "message": "구독항목 저장 성공",
    "data": null,
    "status": "OK"
}
```

이후 title, memo null 값 비 허용하여 빈값("") 요청 유도할지에 대한 고민이 필요합니다!