### PR TITLE
Guttok 15 : 사용자 구독항목 수정 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -11,4 +11,5 @@ public class ResponseMessages {
 
     // userSubscription
     public static final String USER_SUBSCRIPTION_SAVE_SUCCESS = "구독항목 저장 성공";
+    public static final String USER_SUBSCRIPTION_UPDATE_SUCCESS = "구독항목 수정 성공";
 }

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다"),
 
     // subscription
-    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 서비스를 찾을 수 없습니다.");
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 서비스를 찾을 수 없습니다."),
+
+    // userSubscription
+    USER_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 구독항목을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/app/guttokback/global/security/SecurityConfig.java
+++ b/src/main/java/com/app/guttokback/global/security/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                                 "/swagger", "/swagger-ui.html", "/swagger-ui/**",
                                 "/api-docs", "/api-docs/**", "/v3/api-docs/**"
                         ).permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         return http.build();

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -38,7 +38,7 @@ public class UserSubscriptionController {
         return userSubscriptionService.list(userSubscriptionListRequest.toListOption(userId));
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Object>> userSubscriptionUpdate(
             @Valid @RequestBody UserSubscriptionUpdateRequest userSubscriptionUpdateRequest,
             @PathVariable Long id

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -4,6 +4,7 @@ import com.app.guttokback.global.apiResponse.ApiResponse;
 import com.app.guttokback.global.apiResponse.PageResponse;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
+import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
 import com.app.guttokback.subscription.service.UserSubscriptionService;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_SUBSCRIPTION_SAVE_SUCCESS;
+import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_SUBSCRIPTION_UPDATE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +36,14 @@ public class UserSubscriptionController {
             @PathVariable Long userId
     ) {
         return userSubscriptionService.list(userSubscriptionListRequest.toListOption(userId));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<Object>> userSubscriptionUpdate(
+            @Valid @RequestBody UserSubscriptionUpdateRequest userSubscriptionUpdateRequest,
+            @PathVariable Long id
+    ) {
+        userSubscriptionService.update(id, userSubscriptionUpdateRequest.toUpdate());
+        return ApiResponse.success(USER_SUBSCRIPTION_UPDATE_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
+++ b/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
@@ -82,4 +82,21 @@ public class UserSubscriptionEntity extends AuditInformation {
         this.paymentDay = paymentDay;
         this.memo = memo;
     }
+
+    public void update(String title,
+                       long paymentAmount,
+                       PaymentMethod paymentMethod,
+                       LocalDate startDate,
+                       PaymentCycle paymentCycle,
+                       int paymentDay,
+                       String memo
+    ) {
+        this.title = title;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionUpdateRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionUpdateRequest.java
@@ -1,0 +1,70 @@
+package com.app.guttokback.subscription.dto.controllerDto.request;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSubscriptionUpdateRequest {
+
+    private String title;
+
+    @Positive(message = "납부금액은 양수여야 합니다.")
+    private long paymentAmount;
+
+    @NotNull(message = "결제수단을 선택하세요.")
+    private PaymentMethod paymentMethod;
+
+    @NotNull(message = "첫 납부 날짜를 입력하세요.")
+    private LocalDate startDate;
+
+    @NotNull(message = "결제주기를 선택하세요.")
+    private PaymentCycle paymentCycle;
+
+    @Min(value = 1, message = "결제일자는 1 이상이어야 합니다.")
+    @Max(value = 31, message = "결제일자는 31 이하이어야 합니다.")
+    private int paymentDay;
+
+    private String memo;
+
+    @Builder
+    public UserSubscriptionUpdateRequest(String title,
+                                         long paymentAmount,
+                                         PaymentMethod paymentMethod,
+                                         LocalDate startDate,
+                                         PaymentCycle paymentCycle,
+                                         int paymentDay,
+                                         String memo
+    ) {
+        this.title = title;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
+
+    public UserSubscriptionUpdateInfo toUpdate() {
+        return UserSubscriptionUpdateInfo.builder()
+                .title(title)
+                .paymentAmount(paymentAmount)
+                .paymentMethod(paymentMethod)
+                .startDate(startDate)
+                .paymentCycle(paymentCycle)
+                .paymentDay(paymentDay)
+                .memo(memo)
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionUpdateInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionUpdateInfo.java
@@ -1,0 +1,47 @@
+package com.app.guttokback.subscription.dto.serviceDto;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSubscriptionUpdateInfo {
+
+    private String title;
+
+    private long paymentAmount;
+
+    private PaymentMethod paymentMethod;
+
+    private LocalDate startDate;
+
+    private PaymentCycle paymentCycle;
+
+    private int paymentDay;
+
+    private String memo;
+
+    @Builder
+    public UserSubscriptionUpdateInfo(String title,
+                                      long paymentAmount,
+                                      PaymentMethod paymentMethod,
+                                      LocalDate startDate,
+                                      PaymentCycle paymentCycle,
+                                      int paymentDay,
+                                      String memo
+    ) {
+        this.title = title;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.startDate = startDate;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/SubscriptionService.java
@@ -1,0 +1,20 @@
+package com.app.guttokback.subscription.service;
+
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.global.exception.ErrorCode;
+import com.app.guttokback.subscription.domain.SubscriptionEntity;
+import com.app.guttokback.subscription.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    public SubscriptionEntity findSubscriptionById(Long subscriptionId) {
+        return subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new CustomApplicationException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -8,7 +8,7 @@ import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
 import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
 import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
-import com.app.guttokback.subscription.repository.SubscriptionRepository;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
 import com.app.guttokback.subscription.repository.UserSubscriptionQueryRepository;
 import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
 import com.app.guttokback.user.domain.UserEntity;
@@ -25,14 +25,14 @@ import java.util.List;
 public class UserSubscriptionService {
 
     private final UserSubscriptionRepository userSubscriptionRepository;
-    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionService subscriptionService;
     private final UserService userService;
     private final UserSubscriptionQueryRepository userSubscriptionQueryRepository;
 
     @Transactional
     public void save(UserSubscriptionSaveInfo userSubscriptionSaveInfo) {
         UserEntity user = userService.userFindById(userSubscriptionSaveInfo.getUserId());
-        SubscriptionEntity subscription = findSubscriptionById(userSubscriptionSaveInfo.getSubscriptionId());
+        SubscriptionEntity subscription = subscriptionService.findSubscriptionById(userSubscriptionSaveInfo.getSubscriptionId());
 
         userSubscriptionRepository.save(
                 UserSubscriptionEntity.builder()
@@ -69,8 +69,22 @@ public class UserSubscriptionService {
                 );
     }
 
-    private SubscriptionEntity findSubscriptionById(Long subscriptionId) {
-        return subscriptionRepository.findById(subscriptionId)
-                .orElseThrow(() -> new CustomApplicationException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+    @Transactional
+    public void update(Long id, UserSubscriptionUpdateInfo userSubscriptionUpdateInfo) {
+        UserSubscriptionEntity userSubscription = findUserSubscriptionById(id);
+        System.out.println("!!!" + userSubscription.getTitle());
+        userSubscription.update(
+                userSubscriptionUpdateInfo.getTitle(),
+                userSubscriptionUpdateInfo.getPaymentAmount(),
+                userSubscriptionUpdateInfo.getPaymentMethod(),
+                userSubscriptionUpdateInfo.getStartDate(),
+                userSubscriptionUpdateInfo.getPaymentCycle(),
+                userSubscriptionUpdateInfo.getPaymentDay(),
+                userSubscriptionUpdateInfo.getMemo());
+    }
+
+    private UserSubscriptionEntity findUserSubscriptionById(Long id) {
+        return userSubscriptionRepository.findById(id)
+                .orElseThrow(() -> new CustomApplicationException(ErrorCode.USER_SUBSCRIPTION_NOT_FOUND));
     }
 }

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -72,7 +72,6 @@ public class UserSubscriptionService {
     @Transactional
     public void update(Long id, UserSubscriptionUpdateInfo userSubscriptionUpdateInfo) {
         UserSubscriptionEntity userSubscription = findUserSubscriptionById(id);
-        System.out.println("!!!" + userSubscription.getTitle());
         userSubscription.update(
                 userSubscriptionUpdateInfo.getTitle(),
                 userSubscriptionUpdateInfo.getPaymentAmount(),

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -117,7 +117,7 @@ class UserSubscriptionControllerTest {
                 .build();
 
         // when & then
-        mockMvc.perform(put("/api/subscriptions/{id}", testId)
+        mockMvc.perform(patch("/api/subscriptions/{id}", testId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .with(csrf())
                         .content(objectMapper.writeValueAsString(updateRequest)))

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -1,0 +1,130 @@
+package com.app.guttokback.subscription.controller;
+
+import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.ResponseMessages;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
+import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
+import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
+import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
+import com.app.guttokback.subscription.service.UserSubscriptionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserSubscriptionController.class)
+@WithMockUser
+class UserSubscriptionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private UserSubscriptionService userSubscriptionService;
+
+    private final Long testId = 1L;
+
+    @Test
+    @DisplayName("사용자 구독정보 저장 시 요청 데이터가 성공 응답을 반환한다.")
+    public void userSubscriptionSaveTest() throws Exception {
+        // given
+        UserSubscriptionSaveRequest saveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2025-01-01"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(1)
+                .memo("test")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/subscriptions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(saveRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.USER_SUBSCRIPTION_SAVE_SUCCESS));
+
+        verify(userSubscriptionService).save(any(UserSubscriptionSaveInfo.class));
+    }
+
+    @Test
+    @DisplayName("사용자 구독정보 조회 시 요청 데이터가 성공 응답을 반환한다.")
+    public void userSubscriptionListTest() throws Exception {
+        // given
+        UserSubscriptionListRequest listRequest = new UserSubscriptionListRequest(testId, 1L);
+
+        UserSubscriptionListResponse mockResponse = UserSubscriptionListResponse.builder()
+                .title("test")
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(1)
+                .build();
+
+        when(userSubscriptionService.list(any(UserSubscriptionListInfo.class)))
+                .thenReturn(PageResponse.of(Collections.singletonList(mockResponse), 1L, false));
+
+        // when & then
+        mockMvc.perform(get("/api/subscriptions/{userId}", testId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(listRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contents").isNotEmpty())
+                .andExpect(jsonPath("$.size").value(1))
+                .andExpect(jsonPath("$.hasNext").value(false));
+
+        verify(userSubscriptionService).list(any(UserSubscriptionListInfo.class));
+    }
+
+    @Test
+    @DisplayName("사용자 구독정보 저장 시 요청 데이터가 성공 응답을 반환한다.")
+    public void userSubscriptionUpdateTest() throws Exception {
+        // given
+        UserSubscriptionUpdateRequest updateRequest = UserSubscriptionUpdateRequest.builder()
+                .title("update")
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2025-01-01"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(1)
+                .memo("update")
+                .build();
+
+        // when & then
+        mockMvc.perform(put("/api/subscriptions/{id}", testId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.USER_SUBSCRIPTION_UPDATE_SUCCESS));
+
+        verify(userSubscriptionService).update(eq(testId), any(UserSubscriptionUpdateInfo.class));
+    }
+
+}


### PR DESCRIPTION
[PUT] /api/subscriptions/{id}
- 구독항목 미 존재시 예외처리

RequestBody
```json
{
    "title": "제목 수정",
    "paymentAmount": 15000,
    "paymentMethod": "CARD",
    "startDate": "2025-01-01",
    "paymentCycle": "MONTHLY",
    "paymentDay": 18,
    "memo": "메모"
}
```

ResponseBody
```json
{
    "message": "구독항목 수정 성공",
    "data": null,
    "status": "OK"
}
```