### PR TITLE
Guttok 16 : 사용자 구독항목 삭제 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -12,6 +12,7 @@ public class ResponseMessages {
     // userSubscription
     public static final String USER_SUBSCRIPTION_SAVE_SUCCESS = "구독항목 저장 성공";
     public static final String USER_SUBSCRIPTION_UPDATE_SUCCESS = "구독항목 수정 성공";
+    public static final String USER_SUBSCRIPTION_DELETE_SUCCESS = "구독항목 삭제 성공";
 
     // auth
     public static final String USER_LOGIN_SUCCESS = "사용자 로그인 성공";

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -12,8 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_SUBSCRIPTION_SAVE_SUCCESS;
-import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_SUBSCRIPTION_UPDATE_SUCCESS;
+import static com.app.guttokback.global.apiResponse.ResponseMessages.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,5 +44,11 @@ public class UserSubscriptionController {
     ) {
         userSubscriptionService.update(id, userSubscriptionUpdateRequest.toUpdate());
         return ApiResponse.success(USER_SUBSCRIPTION_UPDATE_SUCCESS);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Object>> userSubscriptionDelete(@PathVariable Long id) {
+        userSubscriptionService.delete(id);
+        return ApiResponse.success(USER_SUBSCRIPTION_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -82,6 +82,12 @@ public class UserSubscriptionService {
                 userSubscriptionUpdateInfo.getMemo());
     }
 
+    @Transactional
+    public void delete(Long id) {
+        UserSubscriptionEntity userSubscription = findUserSubscriptionById(id);
+        userSubscriptionRepository.delete(userSubscription);
+    }
+
     private UserSubscriptionEntity findUserSubscriptionById(Long id) {
         return userSubscriptionRepository.findById(id)
                 .orElseThrow(() -> new CustomApplicationException(ErrorCode.USER_SUBSCRIPTION_NOT_FOUND));

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -103,7 +103,7 @@ class UserSubscriptionControllerTest {
     }
 
     @Test
-    @DisplayName("사용자 구독정보 저장 시 요청 데이터가 성공 응답을 반환한다.")
+    @DisplayName("사용자 구독정보 수정 시 요청 데이터가 성공 응답을 반환한다.")
     public void userSubscriptionUpdateTest() throws Exception {
         // given
         UserSubscriptionUpdateRequest updateRequest = UserSubscriptionUpdateRequest.builder()
@@ -127,4 +127,30 @@ class UserSubscriptionControllerTest {
         verify(userSubscriptionService).update(eq(testId), any(UserSubscriptionUpdateInfo.class));
     }
 
+    @Test
+    @DisplayName("사용자 구독정보 삭제 시 요청 데이터가 성공 응답을 반환한다.")
+    public void userSubscriptionDeleteTest() throws Exception {
+        // given
+        UserSubscriptionSaveRequest saveRequest = UserSubscriptionSaveRequest.builder()
+                .userId(1L)
+                .title("test")
+                .subscriptionId(1L)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .startDate(LocalDate.parse("2025-01-01"))
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(1)
+                .memo("test")
+                .build();
+
+        // when & then
+        mockMvc.perform(delete("/api/subscriptions/{id}", testId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(saveRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.USER_SUBSCRIPTION_DELETE_SUCCESS));
+
+        verify(userSubscriptionService).delete(testId);
+    }
 }

--- a/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
@@ -281,4 +281,17 @@ class UserSubscriptionServiceTest {
         assertThat(exception).isInstanceOf(CustomApplicationException.class);
         assertThat(exception.getMessage()).isEqualTo("사용자의 구독항목을 찾을 수 없습니다.");
     }
+
+    @Test
+    @DisplayName("존재하는 구독항목 삭제 시 정상적으로 삭제된다.")
+    public void userSubscriptionDeleteTest() {
+        // given
+        UserSubscriptionEntity userSubscription = createUserSubscription();
+
+        // when
+        userSubscriptionService.delete(userSubscription.getId());
+
+        // then
+        assertThat(userSubscriptionRepository.findById(userSubscription.getId())).isEmpty();
+    }
 }


### PR DESCRIPTION
[DELETE] /api/subscriptions/{id}
- 구독항목 미존재 시 예외처리

- ResponseBody
```json
{
    "message": "구독항목 삭제 성공",
    "data": null,
    "status": "OK"
}
```