### PR TITLE
Guttok 33 : 결제 리마인드 이메일 발송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'software.amazon.awssdk:ses:2.29.46'
 
     // QueryDsl

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     // mail
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'software.amazon.awssdk:ses:2.29.46'
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
 
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'software.amazon.awssdk:ses:2.29.46'
+
     // QueryDsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -17,4 +17,7 @@ public class ResponseMessages {
 
     // auth
     public static final String USER_LOGIN_SUCCESS = "사용자 로그인 성공";
+
+    // mail
+    public static final String MAIL_SEND_SUCCESS = "이메일 발송 성공";
 }

--- a/src/main/java/com/app/guttokback/global/aws/ses/config/SesConfig.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/config/SesConfig.java
@@ -1,0 +1,29 @@
+package com.app.guttokback.global.aws.ses.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+
+@Configuration
+public class SesConfig {
+
+    @Value("${aws.ses.access-key}")
+    private String accessKey;
+    @Value("${aws.ses.secret-key}")
+    private String secretKey;
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public SesClient amazonSimpleEmailService() {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return SesClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/config/TemplateConfig.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/config/TemplateConfig.java
@@ -1,0 +1,18 @@
+package com.app.guttokback.global.aws.ses.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class TemplateConfig {
+
+    @Bean
+    public TemplateEngine htmlTemplateEngine(SpringResourceTemplateResolver springResourceTemplateResolver) {
+        TemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(springResourceTemplateResolver);
+        return templateEngine;
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/controller/EmailController.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/controller/EmailController.java
@@ -1,0 +1,27 @@
+package com.app.guttokback.global.aws.ses.controller;
+
+import com.app.guttokback.global.apiResponse.ApiResponse;
+import com.app.guttokback.global.aws.ses.service.RemainderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.app.guttokback.global.apiResponse.ResponseMessages.MAIL_SEND_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mail")
+public class EmailController {
+
+    private final RemainderService remainderService;
+
+    @PostMapping("/reminder")
+    public ResponseEntity<ApiResponse<String>> sendReminder() {
+        remainderService.sendReminder();
+        return ApiResponse.success(MAIL_SEND_SUCCESS);
+    }
+}
+
+// 테스트를 위한 임시 컨트롤러 → 스케줄러 적용 후 제거

--- a/src/main/java/com/app/guttokback/global/aws/ses/dto/EmailInfo.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/dto/EmailInfo.java
@@ -1,0 +1,51 @@
+package com.app.guttokback.global.aws.ses.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.ses.model.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailInfo {
+
+    private List<String> to;
+    private String subject;
+    private String content;
+
+    @Builder
+    public EmailInfo(String from, List<String> to, String subject, String content) {
+        this.to = to;
+        this.subject = subject;
+        this.content = content;
+    }
+
+    // SES 에서 제공하는 이메일 전송 요청
+    public SendEmailRequest toSendEmailRequest(String sender) {
+        Destination destination = Destination.builder()
+                .toAddresses(this.to)
+                .build();
+
+        Message message = Message.builder()
+                .subject(createContent(this.subject))
+                .body(Body.builder().html(createContent(this.content)).build())
+                .build();
+
+        return SendEmailRequest.builder()
+                .source(sender)
+                .destination(destination)
+                .message(message)
+                .build();
+    }
+
+    // Email Subject, Body UTF-8 설정
+    private Content createContent(String text) {
+        return Content.builder()
+                .charset("UTF-8")
+                .data(text)
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/dto/EmailInfo.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/dto/EmailInfo.java
@@ -17,7 +17,7 @@ public class EmailInfo {
     private String content;
 
     @Builder
-    public EmailInfo(String from, List<String> to, String subject, String content) {
+    public EmailInfo(List<String> to, String subject, String content) {
         this.to = to;
         this.subject = subject;
         this.content = content;

--- a/src/main/java/com/app/guttokback/global/aws/ses/dto/SubscriptionTotalAmountInfo.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/dto/SubscriptionTotalAmountInfo.java
@@ -1,0 +1,20 @@
+package com.app.guttokback.global.aws.ses.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionTotalAmountInfo {
+
+    private Long userId;
+    private Long totalAmount;
+
+    @QueryProjection
+    public SubscriptionTotalAmountInfo(Long userId, Long totalAmount) {
+        this.userId = userId;
+        this.totalAmount = totalAmount;
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/service/EmailService.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/service/EmailService.java
@@ -1,0 +1,26 @@
+package com.app.guttokback.global.aws.ses.service;
+
+import com.app.guttokback.global.aws.ses.dto.EmailInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ses.SesClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    @Value("${aws.ses.send-mail-from}")
+    private String sender;
+    private final SesClient sesClient;
+
+    public void sendEmail(EmailInfo emailInfo) {
+        try {
+            sesClient.sendEmail(emailInfo.toSendEmailRequest(sender));
+        } catch (Exception exception) {
+            log.error("이메일 전송 실패", exception);
+        }
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/service/EmailTemplateService.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/service/EmailTemplateService.java
@@ -1,0 +1,37 @@
+package com.app.guttokback.global.aws.ses.service;
+
+import com.app.guttokback.global.aws.ses.dto.EmailInfo;
+import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import com.app.guttokback.user.domain.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EmailTemplateService {
+
+    private final TemplateEngine templateEngine;
+
+    public EmailInfo createRemainderTemplate(List<UserSubscriptionEntity> userSubscriptions, UserEntity user, long totalAmount) {
+        // 사용자 정보 템플릿 데이터 설정
+        Context context = new Context();
+        context.setVariable("nickName", user.getNickName());
+        context.setVariable("subscriptions", userSubscriptions);
+        context.setVariable("totalAmount", totalAmount);
+
+        // 템플릿을 렌더링하여 HTML 콘텐츠 생성
+        String content = templateEngine.process("reminder-email", context);
+
+        // 이메일 발송 객체 생성
+        return EmailInfo.builder()
+                .to(Collections.singletonList(user.getEmail()))
+                .subject("구똑 - 납부 리마인드")
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/global/aws/ses/service/RemainderService.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/service/RemainderService.java
@@ -1,0 +1,39 @@
+package com.app.guttokback.global.aws.ses.service;
+
+import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import com.app.guttokback.subscription.repository.UserSubscriptionQueryRepository;
+import com.app.guttokback.user.domain.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RemainderService {
+
+    private final UserSubscriptionQueryRepository userSubscriptionQueryRepository;
+    private final EmailService emailService;
+    private final EmailTemplateService emailTemplateService;
+
+    public void sendReminder() {
+        userSubscriptionQueryRepository.findActiveUserSubscriptions()
+                .stream()
+                // 유저 별 그룹화
+                .collect(Collectors.groupingBy(UserSubscriptionEntity::getUser))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    // 유저 별 총 금액 연산
+                    UserEntity user = entry.getKey();
+                    long totalAmount = entry.getValue().stream()
+                            .mapToLong(UserSubscriptionEntity::getPaymentAmount)
+                            .sum();
+                    // 템플릿에 필요한 데이터 전달
+                    return emailTemplateService.createRemainderTemplate(entry.getValue(), user, totalAmount);
+                })
+                .toList()
+                // 유저 별 이메일 전송
+                .forEach(emailService::sendEmail);
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepository.java
+++ b/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.app.guttokback.subscription.domain.QUserSubscriptionEntity.userSubscriptionEntity;
+import static com.app.guttokback.user.domain.QUserEntity.userEntity;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,12 +18,23 @@ public class UserSubscriptionQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    // UserSubscription 리스트 페이징 조회 쿼리
     public List<UserSubscriptionEntity> findPagedUserSubscriptions(UserSubscriptionListInfo userSubscriptionListInfo) {
         return jpaQueryFactory
                 .selectFrom(userSubscriptionEntity)
                 .where(lastIdCondition(userSubscriptionListInfo.getLastId()))
                 .orderBy(userSubscriptionEntity.id.desc())
                 .limit(userSubscriptionListInfo.getSize() + 1)
+                .fetch();
+    }
+
+    // 알림여부 승인한 유저와 구독항목 조회 쿼리
+    public List<UserSubscriptionEntity> findActiveUserSubscriptions() {
+        return jpaQueryFactory
+                .selectFrom(userSubscriptionEntity)
+                .innerJoin(userSubscriptionEntity.user, userEntity)
+                .fetchJoin()
+                .where(userEntity.alarm.eq(true))
                 .fetch();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
         show_sql: true
         format_sql: true
 
+aws:
+  ses:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+    send-mail-from: ${ADMIN_EMAIL}
+  region: ${AWS_REGION}
+
 logging:
   level:
     org:

--- a/src/main/resources/templates/reminder-email.html
+++ b/src/main/resources/templates/reminder-email.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>납부 리마인드</title>
+</head>
+<body>
+<h1>🎉 안녕하세요, <span th:text="${nickName}">사용자 이름</span>님!</h1>
+<p>다음 구독 항목들에 대한 납부 기한이 다가오고 있습니다</p>
+<p>구독 서비스, 납부 일자, 납부 금액 순</p>
+<ul>
+    <li th:each="item : ${subscriptions}">
+        <span th:if="${item.subscription != item.subscription.CUSTOM_INPUT }"
+              th:text="${item.subscription.name}"></span>
+        <span th:if="${item.subscription == item.subscription.CUSTOM_INPUT}" th:text="${item.title}"></span>
+        <span th:text="${item.paymentDay}"></span>일
+        <span th:text="${item.paymentAmount}"></span>원
+    </li>
+</ul>
+<p>총 납부 금액: <span th:text="${totalAmount}"></span>원</p>
+<p>구똑 서비스를 지속적으로 이용해 주셔서 감사합니다.👏</p>
+</body>
+</html>

--- a/src/main/resources/templates/reminder-email.html
+++ b/src/main/resources/templates/reminder-email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>납부 리마인드</title>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,6 +17,13 @@ spring:
         show_sql: true
         format_sql: true
 
+aws:
+  ses:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
+    send-mail-from: ${ADMIN_EMAIL}
+  region: ${AWS_REGION}
+
 logging:
   level:
     org:


### PR DESCRIPTION
[POST] /api/mail/reminder `임시 컨트롤러로 스케줄러 구현 후 제거예정입니다.`

- 이메일 전송 실패 시 log.error로 에러 로그 출력 (exception 처리X)
- `alram = true`인 사용자에게만 이메일 전송
- HTML 템플릿을 사용하여 이메일 데이터 동적 처리 `템플릿 경로 : ./resources/templates`

<img width="369" alt="스크린샷 2025-01-12 19 26 53" src="https://github.com/user-attachments/assets/9d4710d7-db4f-4904-ae4e-79456ab26085" />