### PR TITLE
Guttok 43 : 에러 식별 코드 추가

### DIFF
--- a/src/main/java/com/app/guttokback/global/exception/CustomExceptionResponse.java
+++ b/src/main/java/com/app/guttokback/global/exception/CustomExceptionResponse.java
@@ -6,10 +6,12 @@ import org.springframework.http.HttpStatusCode;
 @Getter
 public class CustomExceptionResponse {
     private final int code;
+    private final String errorCode;
     private final String message;
 
-    public CustomExceptionResponse(HttpStatusCode status, String message) {
+    public CustomExceptionResponse(HttpStatusCode status, String errorCode, String message) {
         this.code = status.value();
+        this.errorCode = errorCode;
         this.message = message;
     }
 }

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
     // user
     ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_01", "회원을 찾을 수 없습니다"),
     EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "USER_02", "중복된 회원이 존재합니다"),
-    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "USER_03", "중복된 이름이 존재합니다"),
+    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "USER_03", "중복된 닉네임이 존재합니다"),
 
     // userSubscription
     USER_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBSCRIPTION_01", "사용자의 구독항목을 찾을 수 없습니다."),

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -6,25 +6,27 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     // user
-    ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
-    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다"),
-    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "중복된 닉네임이 존재합니다"),
+    ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_01", "회원을 찾을 수 없습니다"),
+    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "USER_02", "중복된 회원이 존재합니다"),
+    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "USER_03", "중복된 이름이 존재합니다"),
 
     // userSubscription
-    USER_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 구독항목을 찾을 수 없습니다."),
-    MISSING_TITLE(HttpStatus.BAD_REQUEST, "직접 입력 시 제목은 필수 입력입니다."),
-    INVALID_INPUT_TITLE(HttpStatus.BAD_REQUEST, "직접 입력 시에만 title 입력이 가능합니다."),
+    USER_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBSCRIPTION_01", "사용자의 구독항목을 찾을 수 없습니다."),
+    MISSING_TITLE(HttpStatus.BAD_REQUEST, "SUBSCRIPTION_02", "직접 입력 시 제목은 필수 입력입니다."),
+    INVALID_INPUT_TITLE(HttpStatus.BAD_REQUEST, "SUBSCRIPTION_03", "직접 입력 시에만 title 입력이 가능합니다."),
 
     // auth
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "계정을 찾을 수 없습니다"),
-    SESSION_PROBLEM(HttpStatus.UNAUTHORIZED, "세션이 없거나 만료됐습니다"),
-    USER_ACCESS_PROBLEM(HttpStatus.FORBIDDEN, "리소스에 접근할 권한이 없습니다");
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_01", "계정을 찾을 수 없습니다"),
+    SESSION_PROBLEM(HttpStatus.UNAUTHORIZED, "AUTH_02", "세션이 없거나 만료됐습니다"),
+    USER_ACCESS_PROBLEM(HttpStatus.FORBIDDEN, "AUTH_03", "리소스에 접근할 권한이 없습니다");
 
     private final HttpStatus httpStatus;
+    private final String errorCode;
     private final String message;
 
-    ErrorCode(HttpStatus httpStatus, String message) {
+    ErrorCode(HttpStatus httpStatus, String errorCode, String message) {
         this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
         this.message = message;
     }
 }

--- a/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CustomExceptionResponse> handleCustomApplicationException(CustomApplicationException exception) {
         CustomExceptionResponse errorResponse = new CustomExceptionResponse(
                 exception.getErrorCode().getHttpStatus(),
+                exception.getErrorCode().getErrorCode(),
                 exception.getErrorCode().getMessage()
         );
         return new ResponseEntity<>(errorResponse, exception.getErrorCode().getHttpStatus());


### PR DESCRIPTION
에러 식별 코드 추가

// 기존 코드
```
//user
 ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다"),
    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "중복된 회원이 존재합니다"),
    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "중복된 이름이 존재합니다")
```

// 식별 코드 추가
```
//user
ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_01", "회원을 찾을 수 없습니다"),
    EMAIL_SAME_FOUND(HttpStatus.CONFLICT, "USER_02", "중복된 회원이 존재합니다"),
    NICKNAME_SAME_FOUND(HttpStatus.CONFLICT, "USER_03", "중복된 이름이 존재합니다"),
```