### PR TITLE
Guttok 54 : 구독항목 수정 로그인 정보 주입 적용, startDate 필드 제거

### DIFF
--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -20,10 +20,10 @@ public enum ErrorCode {
     SESSION_PROBLEM(HttpStatus.UNAUTHORIZED, "AUTH_02", "세션이 없거나 만료됐습니다"),
     USER_ACCESS_PROBLEM(HttpStatus.FORBIDDEN, "AUTH_03", "리소스에 접근할 권한이 없습니다"),
     CERTIFICATION_NUMBER_NOT_CORRECT(HttpStatus.UNAUTHORIZED, "AUTH_04", "인증 코드가 올바르지 않습니다"),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH_04", "이 작업을 수행할 권한이 없습니다."),
 
     // email
     OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다");
-
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -46,9 +46,10 @@ public class UserSubscriptionController {
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Object>> userSubscriptionUpdate(
             @Valid @RequestBody UserSubscriptionUpdateRequest userSubscriptionUpdateRequest,
+            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long id
     ) {
-        userSubscriptionService.update(id, userSubscriptionUpdateRequest.toUpdate());
+        userSubscriptionService.update(id, userSubscriptionUpdateRequest.toUpdate(userDetails.getUsername()));
         return ApiResponse.success(USER_SUBSCRIPTION_UPDATE_SUCCESS);
     }
 

--- a/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
+++ b/src/main/java/com/app/guttokback/subscription/domain/UserSubscriptionEntity.java
@@ -41,10 +41,6 @@ public class UserSubscriptionEntity extends AuditInformation {
     @Comment("결제 여부")
     private PaymentStatus paymentStatus;
 
-    @Column(nullable = false)
-    @Comment("첫 납부 날짜")
-    private LocalDate startDate;
-
     @Column(length = 50, nullable = false)
     @Comment("결제 주기")
     private PaymentCycle paymentCycle;
@@ -67,7 +63,6 @@ public class UserSubscriptionEntity extends AuditInformation {
                                   Subscription subscription,
                                   long paymentAmount,
                                   PaymentMethod paymentMethod,
-                                  LocalDate startDate,
                                   PaymentCycle paymentCycle,
                                   int paymentDay,
                                   String memo
@@ -78,7 +73,6 @@ public class UserSubscriptionEntity extends AuditInformation {
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
         this.paymentStatus = PaymentStatus.PENDING;
-        this.startDate = startDate;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;
@@ -87,7 +81,7 @@ public class UserSubscriptionEntity extends AuditInformation {
     public void update(String title,
                        long paymentAmount,
                        PaymentMethod paymentMethod,
-                       LocalDate startDate,
+                       PaymentStatus paymentStatus,
                        PaymentCycle paymentCycle,
                        int paymentDay,
                        String memo
@@ -95,7 +89,7 @@ public class UserSubscriptionEntity extends AuditInformation {
         this.title = title;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.startDate = startDate;
+        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequest.java
@@ -13,8 +13,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSubscriptionSaveRequest {
@@ -30,9 +28,6 @@ public class UserSubscriptionSaveRequest {
     @NotNull(message = "결제수단을 선택하세요.")
     private PaymentMethod paymentMethod;
 
-    @NotNull(message = "첫 납부 날짜를 입력하세요.")
-    private LocalDate startDate;
-
     @NotNull(message = "결제주기를 선택하세요.")
     private PaymentCycle paymentCycle;
 
@@ -47,7 +42,6 @@ public class UserSubscriptionSaveRequest {
                                        Subscription subscription,
                                        long paymentAmount,
                                        PaymentMethod paymentMethod,
-                                       LocalDate startDate,
                                        PaymentCycle paymentCycle,
                                        int paymentDay,
                                        String memo
@@ -56,7 +50,6 @@ public class UserSubscriptionSaveRequest {
         this.subscription = subscription;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.startDate = startDate;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;
@@ -69,7 +62,6 @@ public class UserSubscriptionSaveRequest {
                 .subscription(subscription)
                 .paymentAmount(paymentAmount)
                 .paymentMethod(paymentMethod)
-                .startDate(startDate)
                 .paymentCycle(paymentCycle)
                 .paymentDay(paymentDay)
                 .memo(memo)

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionUpdateRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionUpdateRequest.java
@@ -2,6 +2,7 @@ package com.app.guttokback.subscription.dto.controllerDto.request;
 
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -11,8 +12,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,8 +25,8 @@ public class UserSubscriptionUpdateRequest {
     @NotNull(message = "결제수단을 선택하세요.")
     private PaymentMethod paymentMethod;
 
-    @NotNull(message = "첫 납부 날짜를 입력하세요.")
-    private LocalDate startDate;
+    @NotNull(message = "결제 상태를 선택하세요.")
+    private PaymentStatus paymentStatus;
 
     @NotNull(message = "결제주기를 선택하세요.")
     private PaymentCycle paymentCycle;
@@ -42,7 +41,7 @@ public class UserSubscriptionUpdateRequest {
     public UserSubscriptionUpdateRequest(String title,
                                          long paymentAmount,
                                          PaymentMethod paymentMethod,
-                                         LocalDate startDate,
+                                         PaymentStatus paymentStatus,
                                          PaymentCycle paymentCycle,
                                          int paymentDay,
                                          String memo
@@ -50,18 +49,19 @@ public class UserSubscriptionUpdateRequest {
         this.title = title;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.startDate = startDate;
+        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;
     }
 
-    public UserSubscriptionUpdateInfo toUpdate() {
+    public UserSubscriptionUpdateInfo toUpdate(String email) {
         return UserSubscriptionUpdateInfo.builder()
+                .email(email)
                 .title(title)
                 .paymentAmount(paymentAmount)
                 .paymentMethod(paymentMethod)
-                .startDate(startDate)
+                .paymentStatus(paymentStatus)
                 .paymentCycle(paymentCycle)
                 .paymentDay(paymentDay)
                 .memo(memo)

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/response/UserSubscriptionListResponse.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/response/UserSubscriptionListResponse.java
@@ -1,9 +1,6 @@
 package com.app.guttokback.subscription.dto.controllerDto.response;
 
-import com.app.guttokback.subscription.domain.PaymentCycle;
-import com.app.guttokback.subscription.domain.PaymentMethod;
-import com.app.guttokback.subscription.domain.Subscription;
-import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
+import com.app.guttokback.subscription.domain.*;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,6 +23,8 @@ public class UserSubscriptionListResponse {
 
     private PaymentMethod paymentMethod;
 
+    private PaymentStatus paymentStatus;
+
     private PaymentCycle paymentCycle;
 
     private int paymentDay;
@@ -42,6 +41,7 @@ public class UserSubscriptionListResponse {
                                         Subscription subscription,
                                         long paymentAmount,
                                         PaymentMethod paymentMethod,
+                                        PaymentStatus paymentStatus,
                                         PaymentCycle paymentCycle,
                                         int paymentDay,
                                         LocalDateTime registerDate,
@@ -53,6 +53,7 @@ public class UserSubscriptionListResponse {
         this.subscription = subscription;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
+        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.registerDate = registerDate;
@@ -66,6 +67,7 @@ public class UserSubscriptionListResponse {
                 .subscription(userSubscriptionEntity.getSubscription())
                 .paymentAmount(userSubscriptionEntity.getPaymentAmount())
                 .paymentMethod(userSubscriptionEntity.getPaymentMethod())
+                .paymentStatus(userSubscriptionEntity.getPaymentStatus())
                 .paymentCycle(userSubscriptionEntity.getPaymentCycle())
                 .paymentDay(userSubscriptionEntity.getPaymentDay())
                 .registerDate(userSubscriptionEntity.getRegisterDate())

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionSaveInfo.java
@@ -2,13 +2,12 @@ package com.app.guttokback.subscription.dto.serviceDto;
 
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.domain.Subscription;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,7 +23,7 @@ public class UserSubscriptionSaveInfo {
 
     private PaymentMethod paymentMethod;
 
-    private LocalDate startDate;
+    private PaymentStatus paymentStatus;
 
     private PaymentCycle paymentCycle;
 
@@ -38,7 +37,7 @@ public class UserSubscriptionSaveInfo {
                                     Subscription subscription,
                                     long paymentAmount,
                                     PaymentMethod paymentMethod,
-                                    LocalDate startDate,
+                                    PaymentStatus paymentStatus,
                                     PaymentCycle paymentCycle,
                                     int paymentDay,
                                     String memo
@@ -48,7 +47,7 @@ public class UserSubscriptionSaveInfo {
         this.subscription = subscription;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.startDate = startDate;
+        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionUpdateInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/UserSubscriptionUpdateInfo.java
@@ -2,16 +2,17 @@ package com.app.guttokback.subscription.dto.serviceDto;
 
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSubscriptionUpdateInfo {
+
+    private String email;
 
     private String title;
 
@@ -19,7 +20,7 @@ public class UserSubscriptionUpdateInfo {
 
     private PaymentMethod paymentMethod;
 
-    private LocalDate startDate;
+    private PaymentStatus paymentStatus;
 
     private PaymentCycle paymentCycle;
 
@@ -28,18 +29,20 @@ public class UserSubscriptionUpdateInfo {
     private String memo;
 
     @Builder
-    public UserSubscriptionUpdateInfo(String title,
+    public UserSubscriptionUpdateInfo(String email,
+                                      String title,
                                       long paymentAmount,
                                       PaymentMethod paymentMethod,
-                                      LocalDate startDate,
+                                      PaymentStatus paymentStatus,
                                       PaymentCycle paymentCycle,
                                       int paymentDay,
                                       String memo
     ) {
+        this.email = email;
         this.title = title;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.startDate = startDate;
+        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.memo = memo;

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -45,7 +45,6 @@ public class UserSubscriptionService {
                 .subscription(userSubscriptionSaveInfo.getSubscription())
                 .paymentAmount(userSubscriptionSaveInfo.getPaymentAmount())
                 .paymentMethod(userSubscriptionSaveInfo.getPaymentMethod())
-                .startDate(userSubscriptionSaveInfo.getStartDate())
                 .paymentCycle(userSubscriptionSaveInfo.getPaymentCycle())
                 .paymentDay(userSubscriptionSaveInfo.getPaymentDay())
                 .memo(userSubscriptionSaveInfo.getMemo())
@@ -81,6 +80,9 @@ public class UserSubscriptionService {
     @Transactional
     public void update(Long id, UserSubscriptionUpdateInfo userSubscriptionUpdateInfo) {
         UserSubscriptionEntity userSubscription = findUserSubscriptionById(id);
+        UserEntity user = userService.findByUserEmail(userSubscriptionUpdateInfo.getEmail());
+
+        validateUserSubscriptionOwnership(userSubscription.getUser().getId(), user.getId());
 
         int previousPaymentDay = userSubscription.getPaymentDay();
         PaymentCycle previousPaymentCycle = userSubscription.getPaymentCycle();
@@ -89,7 +91,7 @@ public class UserSubscriptionService {
                 userSubscriptionUpdateInfo.getTitle(),
                 userSubscriptionUpdateInfo.getPaymentAmount(),
                 userSubscriptionUpdateInfo.getPaymentMethod(),
-                userSubscriptionUpdateInfo.getStartDate(),
+                userSubscriptionUpdateInfo.getPaymentStatus(),
                 userSubscriptionUpdateInfo.getPaymentCycle(),
                 userSubscriptionUpdateInfo.getPaymentDay(),
                 userSubscriptionUpdateInfo.getMemo());
@@ -126,6 +128,12 @@ public class UserSubscriptionService {
             if (userSubscriptionSaveInfo.getTitle() != null && !userSubscriptionSaveInfo.getTitle().isEmpty()) {
                 throw new CustomApplicationException(ErrorCode.INVALID_INPUT_TITLE);
             }
+        }
+    }
+
+    private void validateUserSubscriptionOwnership(Long userSubscriptionUserId, Long userId) {
+        if (!userSubscriptionUserId.equals(userId)) {
+            throw new CustomApplicationException(ErrorCode.PERMISSION_DENIED);
         }
     }
 }

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -4,6 +4,7 @@ import com.app.guttokback.global.apiResponse.PageResponse;
 import com.app.guttokback.global.apiResponse.ResponseMessages;
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
@@ -24,12 +25,13 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -57,7 +59,6 @@ class UserSubscriptionControllerTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2025-01-01"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(1)
                 .memo("test")
@@ -112,7 +113,7 @@ class UserSubscriptionControllerTest {
                 .title("update")
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2025-01-01"))
+                .paymentStatus(PaymentStatus.COMPLETED)
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(1)
                 .memo("update")
@@ -138,7 +139,6 @@ class UserSubscriptionControllerTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2025-01-01"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(1)
                 .memo("test")

--- a/src/test/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequestTest.java
+++ b/src/test/java/com/app/guttokback/subscription/dto/controllerDto/request/UserSubscriptionSaveRequestTest.java
@@ -10,11 +10,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.util.Set;
 
 class UserSubscriptionSaveRequestTest {
-    
+
     @Test
     @DisplayName("구독 서비스 ID가 null 일 경우 예외가 발생한다.")
     public void subscriptionIdIsNullValidationTest() {
@@ -25,7 +24,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(null)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(15)
                 .memo("test")
@@ -51,7 +49,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(-1)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(15)
                 .memo("test")
@@ -77,7 +74,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(null)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(15)
                 .memo("test")
@@ -94,32 +90,6 @@ class UserSubscriptionSaveRequestTest {
     }
 
     @Test
-    @DisplayName("첫 납부 날짜가 null 일 경우 예외가 발생한다.")
-    public void startDateIsNullValidationTest() {
-        // given
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        UserSubscriptionSaveRequest userSubscriptionSaveRequest = UserSubscriptionSaveRequest.builder()
-                .title("test")
-                .subscription(Subscription.CUSTOM_INPUT)
-                .paymentAmount(10000)
-                .paymentMethod(PaymentMethod.CARD)
-                .startDate(null)
-                .paymentCycle(PaymentCycle.MONTHLY)
-                .paymentDay(15)
-                .memo("test")
-                .build();
-
-        // when
-        Set<ConstraintViolation<UserSubscriptionSaveRequest>> violations = validator.validate(userSubscriptionSaveRequest);
-
-        // then
-        Assertions.assertThat(violations)
-                .extracting(ConstraintViolation::getMessage)
-                .contains("첫 납부 날짜를 입력하세요.")
-                .hasSize(1);
-    }
-
-    @Test
     @DisplayName("결제주기가 null 일 경우 예외가 발생한다.")
     public void paymentCycleIsNullValidationTest() {
         // given
@@ -129,7 +99,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(null)
                 .paymentDay(15)
                 .memo("test")
@@ -155,7 +124,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(0)
                 .memo("test")
@@ -181,7 +149,6 @@ class UserSubscriptionSaveRequestTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(32)
                 .memo("test")

--- a/src/test/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepositoryTest.java
+++ b/src/test/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepositoryTest.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +58,6 @@ class UserSubscriptionQueryRepositoryTest {
                 .subscription(Subscription.CUSTOM_INPUT)
                 .paymentAmount(10000)
                 .paymentMethod(PaymentMethod.CARD)
-                .startDate(LocalDate.parse("2024-12-27"))
                 .paymentCycle(PaymentCycle.MONTHLY)
                 .paymentDay(15)
                 .memo("test")
@@ -84,8 +82,6 @@ class UserSubscriptionQueryRepositoryTest {
                 .containsExactly(savedUserSubscription.getPaymentAmount());
         assertThat(list).extracting(UserSubscriptionEntity::getPaymentMethod)
                 .containsExactly(savedUserSubscription.getPaymentMethod());
-        assertThat(list).extracting(UserSubscriptionEntity::getStartDate)
-                .containsExactly(savedUserSubscription.getStartDate());
         assertThat(list).extracting(UserSubscriptionEntity::getPaymentCycle)
                 .containsExactly(savedUserSubscription.getPaymentCycle());
         assertThat(list).extracting(UserSubscriptionEntity::getMemo)


### PR DESCRIPTION
- 구독항목 수정에 대해 로그인 정보 주입 적용
- 수정 시 본인이 생성한 구독항목이 아니면 예외 발생
- startDate 필드 제거