### PR TITLE
Guttok 56 : 구독 서비스 리스트 검색기능 추가

### DIFF
--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -2,6 +2,7 @@ package com.app.guttokback.subscription.controller;
 
 import com.app.guttokback.global.apiResponse.ApiResponse;
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.subscription.dto.controllerDto.request.SubscriptionSearchRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
@@ -60,8 +61,8 @@ public class UserSubscriptionController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Object>> subscriptionList() {
-        List<SubscriptionListInfo> subscription = userSubscriptionService.subscriptionList();
+    public ResponseEntity<ApiResponse<Object>> subscriptionList(SubscriptionSearchRequest searchRequest) {
+        List<SubscriptionListInfo> subscription = userSubscriptionService.subscriptionList(searchRequest.toSearch());
         return ApiResponse.success(SUBSCRIPTION_LIST_SUCCESS, subscription);
     }
 }

--- a/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/SubscriptionSearchRequest.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/controllerDto/request/SubscriptionSearchRequest.java
@@ -1,0 +1,23 @@
+package com.app.guttokback.subscription.dto.controllerDto.request;
+
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionSearchInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionSearchRequest {
+
+    private String name;
+
+    @Builder
+    public SubscriptionSearchRequest(String name) {
+        this.name = name;
+    }
+
+    public SubscriptionSearchInfo toSearch() {
+        return SubscriptionSearchInfo.builder().name(name).build();
+    }
+}

--- a/src/main/java/com/app/guttokback/subscription/dto/serviceDto/SubscriptionSearchInfo.java
+++ b/src/main/java/com/app/guttokback/subscription/dto/serviceDto/SubscriptionSearchInfo.java
@@ -1,0 +1,19 @@
+package com.app.guttokback.subscription.dto.serviceDto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionSearchInfo {
+
+    private String name;
+
+    @Builder
+    public SubscriptionSearchInfo(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -8,10 +8,7 @@ import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
+import com.app.guttokback.subscription.dto.serviceDto.*;
 import com.app.guttokback.subscription.repository.UserSubscriptionQueryRepository;
 import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
 import com.app.guttokback.user.domain.UserEntity;
@@ -106,8 +103,13 @@ public class UserSubscriptionService {
         userSubscriptionRepository.delete(userSubscription);
     }
 
-    public List<SubscriptionListInfo> subscriptionList() {
+    public List<SubscriptionListInfo> subscriptionList(SubscriptionSearchInfo subscriptionSearchInfo) {
         return Arrays.stream(Subscription.values())
+                .filter(subscription ->
+                        (subscriptionSearchInfo.getName() == null ||
+                                subscription.name().toLowerCase().contains(subscriptionSearchInfo.getName().toLowerCase()) ||
+                                subscription.getName().toLowerCase().contains(subscriptionSearchInfo.getName().toLowerCase()))
+                )
                 .map(subscription -> new SubscriptionListInfo(subscription.name(), subscription.getName()))
                 .toList();
     }

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -10,10 +10,7 @@ import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptio
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
+import com.app.guttokback.subscription.dto.serviceDto.*;
 import com.app.guttokback.subscription.service.UserSubscriptionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -163,7 +160,7 @@ class UserSubscriptionControllerTest {
                 new SubscriptionListInfo("YOUTUBE_PREMIUM", "유튜브 프리미엄")
         );
 
-        when(userSubscriptionService.subscriptionList()).thenReturn(mockResponse);
+        when(userSubscriptionService.subscriptionList(any(SubscriptionSearchInfo.class))).thenReturn(mockResponse);
 
         // when & then
         mockMvc.perform(get("/api/subscriptions")
@@ -174,6 +171,6 @@ class UserSubscriptionControllerTest {
                 .andExpect(jsonPath("$.data[0].code").value("YOUTUBE_PREMIUM"))
                 .andExpect(jsonPath("$.data[0].name").value("유튜브 프리미엄"));
 
-        verify(userSubscriptionService).subscriptionList();
+        verify(userSubscriptionService).subscriptionList(any(SubscriptionSearchInfo.class));
     }
 }

--- a/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
@@ -4,10 +4,7 @@ import com.app.guttokback.global.apiResponse.PageResponse;
 import com.app.guttokback.global.exception.CustomApplicationException;
 import com.app.guttokback.subscription.domain.*;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
+import com.app.guttokback.subscription.dto.serviceDto.*;
 import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
 import com.app.guttokback.user.domain.UserEntity;
 import com.app.guttokback.user.repository.UserRepository;
@@ -240,12 +237,13 @@ class UserSubscriptionServiceTest {
     @DisplayName("구독 서비스 조회 시 Subscription 클래스가 응답된다.")
     public void subscriptionListTest() {
         // given
+        SubscriptionSearchInfo subscriptionSearchInfo = new SubscriptionSearchInfo(null);
         List<SubscriptionListInfo> subscriptions = Arrays.stream(Subscription.values())
                 .map(subscription -> new SubscriptionListInfo(subscription.name(), subscription.getName()))
                 .toList();
 
         // when
-        List<SubscriptionListInfo> subscriptionList = userSubscriptionService.subscriptionList();
+        List<SubscriptionListInfo> subscriptionList = userSubscriptionService.subscriptionList(subscriptionSearchInfo);
 
         // then
         assertThat(subscriptionList).isNotNull();


### PR DESCRIPTION
[GET] /api/subscriptions → 구독 서비스 전체 리스트 응답
```json
{
    "message": "구독 서비스 응답 성공",
    "data": [
        {
            "code": "CUSTOM_INPUT",
            "name": "직접 입력"
        },
        {
            "code": "YOUTUBE_PREMIUM",
            "name": "유튜브 프리미엄"
        },
        {
            "code": "NETFLIX",
            "name": "넷플릭스"
        },
         이후 데이터...
```

[GET] /api/subscriptions?name=you → code, name에 따른 검색된 결과 응답
```json
{
    "message": "구독 서비스 응답 성공",
    "data": [
        {
            "code": "YOUTUBE_PREMIUM",
            "name": "유튜브 프리미엄"
        }
    ],
    "status": "OK"
}
```