### PR TITLE
Guttok 50 - 회원가입 이메일 인증 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -9,6 +9,7 @@ public class ResponseMessages {
     public static final String ALARM_UPDATE_SUCCESS = "알림 수정 성공";
     public static final String USER_DELETE_SUCCESS = "유저 삭제 성공";
     public static final String CERTIFICATION_NUMBER_SUCCESS = "비밀번호 찾기 인증 성공";
+    public static final String EMAIL_VERIFICATIOIN_SUCCESS = "이메일 인증 성공";
 
     // userSubscription
     public static final String USER_SUBSCRIPTION_SAVE_SUCCESS = "구독항목 저장 성공";

--- a/src/main/java/com/app/guttokback/global/aws/ses/controller/EmailController.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/controller/EmailController.java
@@ -21,7 +21,7 @@ public class EmailController {
     private final CertificationService certificationService;
 
     @PostMapping("/certification")
-    public ResponseEntity<ApiResponse<Object>> userFindPassword(@Valid @RequestBody UserEmailRequestDto userEmailRequestDto) {
+    public ResponseEntity<ApiResponse<Object>> userCertificationEmail(@Valid @RequestBody UserEmailRequestDto userEmailRequestDto) {
         certificationService.sendCertificationNumber(userEmailRequestDto.getEmailDto());
         return ApiResponse.success(CERTIFICATION_EMAIL_SEND_SUCCESS);
     }

--- a/src/main/java/com/app/guttokback/global/aws/ses/service/CertificationService.java
+++ b/src/main/java/com/app/guttokback/global/aws/ses/service/CertificationService.java
@@ -22,7 +22,7 @@ public class CertificationService {
     private String createCertificationNumber() {
         String chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         SecureRandom random = new SecureRandom();
-        return random.ints(4, 0, chars.length())
+        return random.ints(6, 0, chars.length())
                 .mapToObj(chars::charAt)
                 .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
                 .toString();

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -20,9 +20,9 @@ public enum ErrorCode {
     SESSION_PROBLEM(HttpStatus.UNAUTHORIZED, "AUTH_02", "세션이 없거나 만료됐습니다"),
     USER_ACCESS_PROBLEM(HttpStatus.FORBIDDEN, "AUTH_03", "리소스에 접근할 권한이 없습니다"),
     CERTIFICATION_NUMBER_NOT_CORRECT(HttpStatus.UNAUTHORIZED, "AUTH_04", "인증 코드가 올바르지 않습니다"),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH_04", "이 작업을 수행할 권한이 없습니다."),
-    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "AUTH_05", "유효하지 않은 세션입니다."),
-    EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH_06", "입력된 이메일과 세션 이메일이 일치하지 않습니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH_05", "이 작업을 수행할 권한이 없습니다."),
+    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "AUTH_06", "유효하지 않은 세션입니다."),
+    EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH_07", "입력된 이메일과 세션 이메일이 일치하지 않습니다."),
 
     // email
     OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다");

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -21,9 +21,12 @@ public enum ErrorCode {
     USER_ACCESS_PROBLEM(HttpStatus.FORBIDDEN, "AUTH_03", "리소스에 접근할 권한이 없습니다"),
     CERTIFICATION_NUMBER_NOT_CORRECT(HttpStatus.UNAUTHORIZED, "AUTH_04", "인증 코드가 올바르지 않습니다"),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH_04", "이 작업을 수행할 권한이 없습니다."),
+    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "AUTH_05", "유효하지 않은 세션입니다."),
+    EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH_06", "입력된 이메일과 세션 이메일이 일치하지 않습니다."),
 
     // email
     OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/app/guttokback/user/controller/AuthController.java
+++ b/src/main/java/com/app/guttokback/user/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.app.guttokback.user.controller;
 
 import com.app.guttokback.global.apiResponse.ApiResponse;
 import com.app.guttokback.user.dto.controllerDto.LoginRequestDto;
+import com.app.guttokback.user.dto.controllerDto.UserCertificationNumberRequestDto;
+import com.app.guttokback.user.service.UserCertificationNumberService;
 import com.app.guttokback.user.service.UserService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,8 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_LOGIN_SUCCESS;
-import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_LOGOUT_SUCCESS;
+import static com.app.guttokback.global.apiResponse.ResponseMessages.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -26,6 +27,7 @@ import static com.app.guttokback.global.apiResponse.ResponseMessages.USER_LOGOUT
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
+    private final UserCertificationNumberService userCertificationNumberService;
     private final UserService userService;
 
     @PostMapping("/signin")
@@ -71,5 +73,17 @@ public class AuthController {
         response.addCookie(cookie);
 
         return ApiResponse.success(USER_LOGOUT_SUCCESS);
+    }
+
+    @PostMapping("/certification-number")
+    public ResponseEntity<ApiResponse<Object>> userCertificationNumber(@Valid @RequestBody UserCertificationNumberRequestDto userCertificationNumberRequestDto, HttpServletRequest request) {
+        userCertificationNumberService.responseSession(userCertificationNumberRequestDto.getCertificationNumberDto(), request);
+        return ApiResponse.success(CERTIFICATION_NUMBER_SUCCESS);
+    }
+
+    @PostMapping("/email-verification")
+    public ResponseEntity<ApiResponse<Object>> userEmailVerification(@Valid @RequestBody UserCertificationNumberRequestDto userCertificationNumberRequestDto, HttpServletRequest request) {
+        userCertificationNumberService.createUnauthenticatedSession(userCertificationNumberRequestDto.getCertificationNumberDto(), request);
+        return ApiResponse.success(EMAIL_VERIFICATIOIN_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/user/controller/UserController.java
+++ b/src/main/java/com/app/guttokback/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.app.guttokback.user.controller;
 
 import com.app.guttokback.global.apiResponse.ApiResponse;
-import com.app.guttokback.user.dto.controllerDto.UserCertificationNumberRequestDto;
 import com.app.guttokback.user.dto.controllerDto.UserNicknameUpdateRequestDto;
 import com.app.guttokback.user.dto.controllerDto.UserPasswordUpdateRequestDto;
 import com.app.guttokback.user.dto.controllerDto.UserSaveRequestDto;
@@ -24,7 +23,6 @@ import static com.app.guttokback.global.apiResponse.ResponseMessages.*;
 @RequestMapping("api/users")
 public class UserController {
     private final UserService userService;
-    private final UserCertificationNumberService userCertificationNumberService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<UserDetailDto>> userDetail(@AuthenticationPrincipal UserDetails userDetails) {
@@ -33,8 +31,8 @@ public class UserController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Object>> userSave(@Valid @RequestBody UserSaveRequestDto userSaveRequestDto) {
-        userService.userSave(userSaveRequestDto.userSaveDto());
+    public ResponseEntity<ApiResponse<Object>> userSave(@Valid @RequestBody UserSaveRequestDto userSaveRequestDto, HttpServletRequest request) {
+        userService.userSave(userSaveRequestDto.userSaveDto(), request);
         return ApiResponse.success(USER_SAVE_SUCCESS);
     }
 
@@ -60,11 +58,5 @@ public class UserController {
     public ResponseEntity<ApiResponse<Object>> userDelete(@AuthenticationPrincipal UserDetails userDetails) {
         userService.userDelete(userDetails.getUsername());
         return ApiResponse.success(USER_DELETE_SUCCESS);
-    }
-
-    @PostMapping("/certification-number")
-    public ResponseEntity<ApiResponse<Object>> userCertificationNumber(@Valid @RequestBody UserCertificationNumberRequestDto userCertificationNumberRequestDto, HttpServletRequest request) {
-        userCertificationNumberService.responseSession(userCertificationNumberRequestDto.getCertificationNumberDto(), request);
-        return ApiResponse.success(CERTIFICATION_NUMBER_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/user/controller/UserController.java
+++ b/src/main/java/com/app/guttokback/user/controller/UserController.java
@@ -5,7 +5,6 @@ import com.app.guttokback.user.dto.controllerDto.UserNicknameUpdateRequestDto;
 import com.app.guttokback.user.dto.controllerDto.UserPasswordUpdateRequestDto;
 import com.app.guttokback.user.dto.controllerDto.UserSaveRequestDto;
 import com.app.guttokback.user.dto.serviceDto.UserDetailDto;
-import com.app.guttokback.user.service.UserCertificationNumberService;
 import com.app.guttokback.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;

--- a/src/main/java/com/app/guttokback/user/service/UserCertificationNumberService.java
+++ b/src/main/java/com/app/guttokback/user/service/UserCertificationNumberService.java
@@ -72,4 +72,25 @@ public class UserCertificationNumberService {
         session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
     }
 
+    // 인증 코드 일치 시 권한 없는 세션 생성 및 반환
+    public void createUnauthenticatedSession(GetCertificationNumberDto getCertificationNumberDto, HttpServletRequest request) {
+
+        certification(getCertificationNumberDto);
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        session = request.getSession(true);
+
+        session.setMaxInactiveInterval(600);
+
+        String email = getCertificationNumberDto.getEmail();
+        session.setAttribute("email", email);
+
+        // 권한 없이 세션 반환
+        SecurityContextHolder.clearContext();
+    }
+
+
 }

--- a/src/main/java/com/app/guttokback/user/service/UserService.java
+++ b/src/main/java/com/app/guttokback/user/service/UserService.java
@@ -10,6 +10,8 @@ import com.app.guttokback.user.dto.serviceDto.UpdatePasswordDto;
 import com.app.guttokback.user.dto.serviceDto.UserDetailDto;
 import com.app.guttokback.user.dto.serviceDto.UserSaveDto;
 import com.app.guttokback.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,7 +27,21 @@ public class UserService {
     private final ReminderService reminderService;
 
     @Transactional
-    public void userSave(UserSaveDto userSaveDto) {
+    public void userSave(UserSaveDto userSaveDto, HttpServletRequest request) {
+
+        // 세션에서 이메일 확인
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("email") == null) {
+            throw new CustomApplicationException(ErrorCode.INVALID_SESSION);
+        }
+
+        String sessionEmail = (String) session.getAttribute("email");
+
+        // 세션 이메일과 입력된 이메일이 일치하는지 확인
+        if (!sessionEmail.equals(userSaveDto.getEmail())) {
+            throw new CustomApplicationException(ErrorCode.EMAIL_NOT_MATCH);
+        }
+
         isEmailDuplicate(userSaveDto.getEmail());
         isNickNameDuplicate(userSaveDto.getNickName());
         userRepository.save(UserEntity.builder()

--- a/src/main/resources/templates/CertificationNumber-email.html
+++ b/src/main/resources/templates/CertificationNumber-email.html
@@ -10,8 +10,8 @@
     <h1>인증번호 확인</h1>
   </div>
   <div class="email-body">
-    <p>안녕하세요, 구똑 비밀번호 변경 인증 코드입니다</p>
-    <p>아래 인증번호를 입력해 주세요!</p>
+    <p>안녕하세요, 구똑 인증 코드입니다</p>
+    <p>아래 인증 코드를 입력해 주세요!</p>
     <div class="auth-code-container">
       <h1 class="auth-code" th:text="${authCode}">코드입력</h1>
     </div>


### PR DESCRIPTION
http://localhost:8080/api/users/email-verification (post)
// 인증번호 검증

```
{
  "email": "jucheol9877@naver.com",
  "certificationNumber" : "oFoO7J"
}
```
http://localhost:8080/api/mail/certification (post)
// 인증번호 이메일로 요청

```
{
  "email": "jucheol9877@naver.com"
}
```


동작 로직
1. 회원가입 시 이메일을 입력하고 이메일 검증 버튼 클릭
2. http://localhost:8080/api/mail/certification 가 동작해서 이메일로 인증코드 전송
3. http://localhost:8080/api/users/email-verification을 이용해서 인증번호가 맞다면 세션 반환
4. sinup을 진행하면서 이메일, 닉네임 등과 같은 정보와 세션을 함께 반환 (세션 10분 후 만료)
5. 세션이 일치한다면 정상적으로 회원가입 진행