### PR TITLE
Guttok-62 : 구독서비스 그룹 Entity 추가

### DIFF
--- a/src/main/java/com/app/guttokback/group/domain/GroupMemberEntity.java
+++ b/src/main/java/com/app/guttokback/group/domain/GroupMemberEntity.java
@@ -1,0 +1,20 @@
+package com.app.guttokback.group.domain;
+
+import com.app.guttokback.global.jpa.AuditInformation;
+import com.app.guttokback.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "GROUP_MEMBERS")
+public class GroupMemberEntity extends AuditInformation {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private SubscriptionGroupEntity subscriptionGroup;
+}

--- a/src/main/java/com/app/guttokback/group/domain/SubscriptionGroupEntity.java
+++ b/src/main/java/com/app/guttokback/group/domain/SubscriptionGroupEntity.java
@@ -1,0 +1,61 @@
+package com.app.guttokback.group.domain;
+
+import com.app.guttokback.global.jpa.AuditInformation;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
+import com.app.guttokback.subscription.domain.Subscription;
+import com.app.guttokback.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "SUBSCRIPTION_GROUPS")
+public class SubscriptionGroupEntity extends AuditInformation {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("그룹 생성자")
+    private UserEntity user;
+
+    @Column(length = 50, nullable = false)
+    @Comment("그룹명")
+    private String name;
+
+    @Column(length = 50, nullable = false)
+    @Comment("구독 서비스")
+    private Subscription subscription;
+
+    @Column(nullable = false)
+    @Comment("납부 금액")
+    private long paymentAmount;
+
+    @Column(length = 50, nullable = false)
+    @Comment("결제 수단")
+    private PaymentMethod paymentMethod;
+
+    @Column(length = 50, nullable = false)
+    @Comment("결제 여부")
+    private PaymentStatus paymentStatus;
+
+    @Column(length = 50, nullable = false)
+    @Comment("결제 주기")
+    private PaymentCycle paymentCycle;
+
+    @Column(nullable = false)
+    @Comment("납부 일")
+    private int paymentDay;
+
+    @Column(nullable = true)
+    @Comment("리마인드 이메일 발송 예정일")
+    private LocalDate reminderDate;
+
+    @Column(length = 250, nullable = true)
+    @Comment("공지사항")
+    private String notice;
+
+}


### PR DESCRIPTION
구독서비스 그룹 Entity 연관관계 매핑하여 추가하였습니다.

groups의 경우 MySQL 예약어로 되어있어 subscription_groups로 생성하였습니다.

그룹장 역할로 그룹 생성 시 생성한 사용자의 id를 받아 사용할 수 있도록 매핑하였습니다.

users - subscription_groups 1:N
users - group_members 1:N
subscription_groups - group_members 1:N

현재까지 생성된 ERD는 다음과 같습니다.
![team-project (1)](https://github.com/user-attachments/assets/b47551c1-c5b8-427d-8aa4-51857079ac77)