### PR TITLE
Guttok 63 : 구독서비스 그룹 생성 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -23,6 +23,8 @@ public class ResponseMessages {
     public static final String SESSION_VALID = "유효 세션";
 
     // mail
-    public static final String REMINDER_EMAIL_SEND_SUCCESS = "리마인더 이메일 발송 성공";
     public static final String CERTIFICATION_EMAIL_SEND_SUCCESS = "인증코드 이메일 발송 성공";
+
+    // group
+    public static final String SUBSCRIPTION_GROUP_SAVE_SUCCESS = "그룹 생성 성공";
 }

--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -25,8 +25,10 @@ public enum ErrorCode {
     EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH_07", "입력된 이메일과 세션 이메일이 일치하지 않습니다."),
 
     // email
-    OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다");
+    OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다"),
 
+    // group
+    MEMBER_ALREADY_JOINED_GROUP(HttpStatus.CONFLICT, "GROUP_02", "이미 참가한 그룹입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/app/guttokback/group/controller/SubscriptionGroupController.java
+++ b/src/main/java/com/app/guttokback/group/controller/SubscriptionGroupController.java
@@ -1,0 +1,32 @@
+package com.app.guttokback.group.controller;
+
+import com.app.guttokback.global.apiResponse.ApiResponse;
+import com.app.guttokback.global.apiResponse.ResponseMessages;
+import com.app.guttokback.group.dto.controllerDto.SubscriptionGroupSaveRequest;
+import com.app.guttokback.group.service.SubscriptionGroupService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class SubscriptionGroupController {
+
+    private final SubscriptionGroupService subscriptionGroupService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> SubscriptionGroupSave(
+            @Valid @RequestBody SubscriptionGroupSaveRequest subscriptionGroupSaveRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        subscriptionGroupService.save(subscriptionGroupSaveRequest.toSave(userDetails.getUsername()));
+        return ApiResponse.success(ResponseMessages.SUBSCRIPTION_GROUP_SAVE_SUCCESS);
+    }
+}

--- a/src/main/java/com/app/guttokback/group/domain/GroupMemberEntity.java
+++ b/src/main/java/com/app/guttokback/group/domain/GroupMemberEntity.java
@@ -3,11 +3,15 @@ package com.app.guttokback.group.domain;
 import com.app.guttokback.global.jpa.AuditInformation;
 import com.app.guttokback.user.domain.UserEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "GROUP_MEMBERS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupMemberEntity extends AuditInformation {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -17,4 +21,10 @@ public class GroupMemberEntity extends AuditInformation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)
     private SubscriptionGroupEntity subscriptionGroup;
+
+    @Builder
+    public GroupMemberEntity(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
+        this.user = user;
+        this.subscriptionGroup = subscriptionGroup;
+    }
 }

--- a/src/main/java/com/app/guttokback/group/domain/SubscriptionGroupEntity.java
+++ b/src/main/java/com/app/guttokback/group/domain/SubscriptionGroupEntity.java
@@ -7,7 +7,10 @@ import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.user.domain.UserEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
@@ -15,6 +18,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Table(name = "SUBSCRIPTION_GROUPS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubscriptionGroupEntity extends AuditInformation {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -24,7 +28,7 @@ public class SubscriptionGroupEntity extends AuditInformation {
 
     @Column(length = 50, nullable = false)
     @Comment("그룹명")
-    private String name;
+    private String title;
 
     @Column(length = 50, nullable = false)
     @Comment("구독 서비스")
@@ -58,4 +62,24 @@ public class SubscriptionGroupEntity extends AuditInformation {
     @Comment("공지사항")
     private String notice;
 
+    @Builder
+    public SubscriptionGroupEntity(UserEntity user,
+                                   String title,
+                                   Subscription subscription,
+                                   long paymentAmount,
+                                   PaymentMethod paymentMethod,
+                                   PaymentCycle paymentCycle,
+                                   int paymentDay,
+                                   String notice
+    ) {
+        this.user = user;
+        this.title = title;
+        this.subscription = subscription;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = PaymentStatus.PENDING;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.notice = notice;
+    }
 }

--- a/src/main/java/com/app/guttokback/group/dto/controllerDto/SubscriptionGroupSaveRequest.java
+++ b/src/main/java/com/app/guttokback/group/dto/controllerDto/SubscriptionGroupSaveRequest.java
@@ -1,0 +1,68 @@
+package com.app.guttokback.group.dto.controllerDto;
+
+import com.app.guttokback.group.dto.serviceDto.SubscriptionGroupSaveInfo;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.Subscription;
+import jakarta.validation.constraints.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionGroupSaveRequest {
+
+    @NotBlank(message = "그룹명을 입력하세요.")
+    private String title;
+
+    @NotNull(message = "항목을 선택하세요.")
+    private Subscription subscription;
+
+    @Positive(message = "납부금액은 양수여야 합니다.")
+    private long paymentAmount;
+
+    @NotNull(message = "결제수단을 선택하세요.")
+    private PaymentMethod paymentMethod;
+
+    @NotNull(message = "결제주기를 선택하세요.")
+    private PaymentCycle paymentCycle;
+
+    @Min(value = 1, message = "결제일자는 1 이상이어야 합니다.")
+    @Max(value = 31, message = "결제일자는 31 이하이어야 합니다.")
+    private int paymentDay;
+
+    private String notice;
+
+    @Builder
+    public SubscriptionGroupSaveRequest(String title,
+                                        Subscription subscription,
+                                        long paymentAmount,
+                                        PaymentMethod paymentMethod,
+                                        PaymentCycle paymentCycle,
+                                        int paymentDay,
+                                        String notice
+    ) {
+        this.title = title;
+        this.subscription = subscription;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.notice = notice;
+    }
+
+    public SubscriptionGroupSaveInfo toSave(String email) {
+        return SubscriptionGroupSaveInfo.builder()
+                .email(email)
+                .title(title)
+                .subscription(subscription)
+                .paymentAmount(paymentAmount)
+                .paymentMethod(paymentMethod)
+                .paymentCycle(paymentCycle)
+                .paymentDay(paymentDay)
+                .notice(notice)
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
+++ b/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
@@ -1,0 +1,55 @@
+package com.app.guttokback.group.dto.serviceDto;
+
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.PaymentStatus;
+import com.app.guttokback.subscription.domain.Subscription;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionGroupSaveInfo {
+
+    private String email;
+
+    private String title;
+
+    private Subscription subscription;
+
+    private long paymentAmount;
+
+    private PaymentMethod paymentMethod;
+
+    private PaymentStatus paymentStatus;
+
+    private PaymentCycle paymentCycle;
+
+    private int paymentDay;
+
+    private String notice;
+
+    @Builder
+    public SubscriptionGroupSaveInfo(String email,
+                                     String title,
+                                     Subscription subscription,
+                                     long paymentAmount,
+                                     PaymentMethod paymentMethod,
+                                     PaymentStatus paymentStatus,
+                                     PaymentCycle paymentCycle,
+                                     int paymentDay,
+                                     String notice
+    ) {
+        this.email = email;
+        this.title = title;
+        this.subscription = subscription;
+        this.paymentAmount = paymentAmount;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = paymentStatus;
+        this.paymentCycle = paymentCycle;
+        this.paymentDay = paymentDay;
+        this.notice = notice;
+    }
+}

--- a/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
+++ b/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
@@ -2,7 +2,6 @@ package com.app.guttokback.group.dto.serviceDto;
 
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
-import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.domain.Subscription;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,8 +21,6 @@ public class SubscriptionGroupSaveInfo {
     private long paymentAmount;
 
     private PaymentMethod paymentMethod;
-
-    private PaymentStatus paymentStatus;
 
     private PaymentCycle paymentCycle;
 

--- a/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
+++ b/src/main/java/com/app/guttokback/group/dto/serviceDto/SubscriptionGroupSaveInfo.java
@@ -37,7 +37,6 @@ public class SubscriptionGroupSaveInfo {
                                      Subscription subscription,
                                      long paymentAmount,
                                      PaymentMethod paymentMethod,
-                                     PaymentStatus paymentStatus,
                                      PaymentCycle paymentCycle,
                                      int paymentDay,
                                      String notice
@@ -47,7 +46,6 @@ public class SubscriptionGroupSaveInfo {
         this.subscription = subscription;
         this.paymentAmount = paymentAmount;
         this.paymentMethod = paymentMethod;
-        this.paymentStatus = paymentStatus;
         this.paymentCycle = paymentCycle;
         this.paymentDay = paymentDay;
         this.notice = notice;

--- a/src/main/java/com/app/guttokback/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/app/guttokback/group/repository/GroupMemberRepository.java
@@ -1,0 +1,8 @@
+package com.app.guttokback.group.repository;
+
+import com.app.guttokback.group.domain.GroupMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMemberEntity, Long> {
+    
+}

--- a/src/main/java/com/app/guttokback/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/app/guttokback/group/repository/GroupMemberRepository.java
@@ -1,8 +1,12 @@
 package com.app.guttokback.group.repository;
 
 import com.app.guttokback.group.domain.GroupMemberEntity;
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.user.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMemberEntity, Long> {
-    
+
+    boolean existsByUserAndSubscriptionGroup(UserEntity user, SubscriptionGroupEntity subscriptionGroup);
+
 }

--- a/src/main/java/com/app/guttokback/group/repository/SubscriptionGroupRepository.java
+++ b/src/main/java/com/app/guttokback/group/repository/SubscriptionGroupRepository.java
@@ -1,0 +1,8 @@
+package com.app.guttokback.group.repository;
+
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionGroupRepository extends JpaRepository<SubscriptionGroupEntity, Long> {
+    
+}

--- a/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
+++ b/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
@@ -1,0 +1,27 @@
+package com.app.guttokback.group.service;
+
+import com.app.guttokback.group.domain.GroupMemberEntity;
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.group.repository.GroupMemberRepository;
+import com.app.guttokback.user.domain.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupMemberService {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    @Transactional
+    public void addMember(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
+        GroupMemberEntity groupMemberEntity = GroupMemberEntity.builder()
+                .user(user)
+                .subscriptionGroup(subscriptionGroup)
+                .build();
+
+        groupMemberRepository.save(groupMemberEntity);
+    }
+}

--- a/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
+++ b/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
@@ -19,7 +19,7 @@ public class GroupMemberService {
 
     @Transactional
     public void addMember(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
-        validateMember(user, subscriptionGroup);
+        validateJoinGroup(user, subscriptionGroup);
         GroupMemberEntity groupMemberEntity = GroupMemberEntity.builder()
                 .user(user)
                 .subscriptionGroup(subscriptionGroup)
@@ -28,7 +28,7 @@ public class GroupMemberService {
         groupMemberRepository.save(groupMemberEntity);
     }
 
-    private void validateMember(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
+    private void validateJoinGroup(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
         if (groupMemberRepository.existsByUserAndSubscriptionGroup(user, subscriptionGroup)) {
             throw new CustomApplicationException(ErrorCode.MEMBER_ALREADY_JOINED_GROUP);
         }

--- a/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
+++ b/src/main/java/com/app/guttokback/group/service/GroupMemberService.java
@@ -1,5 +1,7 @@
 package com.app.guttokback.group.service;
 
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.global.exception.ErrorCode;
 import com.app.guttokback.group.domain.GroupMemberEntity;
 import com.app.guttokback.group.domain.SubscriptionGroupEntity;
 import com.app.guttokback.group.repository.GroupMemberRepository;
@@ -17,6 +19,7 @@ public class GroupMemberService {
 
     @Transactional
     public void addMember(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
+        validateMember(user, subscriptionGroup);
         GroupMemberEntity groupMemberEntity = GroupMemberEntity.builder()
                 .user(user)
                 .subscriptionGroup(subscriptionGroup)
@@ -24,4 +27,11 @@ public class GroupMemberService {
 
         groupMemberRepository.save(groupMemberEntity);
     }
+
+    private void validateMember(UserEntity user, SubscriptionGroupEntity subscriptionGroup) {
+        if (groupMemberRepository.existsByUserAndSubscriptionGroup(user, subscriptionGroup)) {
+            throw new CustomApplicationException(ErrorCode.MEMBER_ALREADY_JOINED_GROUP);
+        }
+    }
+
 }

--- a/src/main/java/com/app/guttokback/group/service/SubscriptionGroupService.java
+++ b/src/main/java/com/app/guttokback/group/service/SubscriptionGroupService.java
@@ -1,0 +1,41 @@
+package com.app.guttokback.group.service;
+
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.group.dto.serviceDto.SubscriptionGroupSaveInfo;
+import com.app.guttokback.group.repository.SubscriptionGroupRepository;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionGroupService {
+
+    private final SubscriptionGroupRepository subscriptionGroupRepository;
+    private final UserService userService;
+    private final GroupMemberService groupMemberService;
+
+    @Transactional
+    public void save(SubscriptionGroupSaveInfo subscriptionGroupSaveInfo) {
+        UserEntity user = userService.findByUserEmail(subscriptionGroupSaveInfo.getEmail());
+
+        SubscriptionGroupEntity subscriptionGroupEntity = SubscriptionGroupEntity.builder()
+                .user(user)
+                .title(subscriptionGroupSaveInfo.getTitle())
+                .subscription(subscriptionGroupSaveInfo.getSubscription())
+                .paymentAmount(subscriptionGroupSaveInfo.getPaymentAmount())
+                .paymentMethod(subscriptionGroupSaveInfo.getPaymentMethod())
+                .paymentCycle(subscriptionGroupSaveInfo.getPaymentCycle())
+                .paymentDay(subscriptionGroupSaveInfo.getPaymentDay())
+                .notice(subscriptionGroupSaveInfo.getNotice())
+                .build();
+
+        subscriptionGroupRepository.save(subscriptionGroupEntity);
+
+        groupMemberService.addMember(user, subscriptionGroupEntity);
+    }
+
+}

--- a/src/test/java/com/app/guttokback/group/controller/SubscriptionGroupControllerTest.java
+++ b/src/test/java/com/app/guttokback/group/controller/SubscriptionGroupControllerTest.java
@@ -1,0 +1,64 @@
+package com.app.guttokback.group.controller;
+
+import com.app.guttokback.global.apiResponse.ResponseMessages;
+import com.app.guttokback.group.dto.controllerDto.SubscriptionGroupSaveRequest;
+import com.app.guttokback.group.dto.serviceDto.SubscriptionGroupSaveInfo;
+import com.app.guttokback.group.service.SubscriptionGroupService;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.Subscription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(SubscriptionGroupController.class)
+@WithMockUser
+class SubscriptionGroupControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private SubscriptionGroupService subscriptionGroupService;
+
+    @Test
+    @DisplayName("그룹 정보 저장 시 요청 데이터가 성공 응답을 반환한다.")
+    public void SubscriptionGroupSaveTest() throws Exception {
+        // given
+        SubscriptionGroupSaveRequest saveRequest = SubscriptionGroupSaveRequest.builder()
+                .title("test")
+                .subscription(Subscription.CUSTOM_INPUT)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .paymentDay(15)
+                .notice("test")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(saveRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.SUBSCRIPTION_GROUP_SAVE_SUCCESS));
+
+        verify(subscriptionGroupService).save(any(SubscriptionGroupSaveInfo.class));
+    }
+
+}

--- a/src/test/java/com/app/guttokback/group/repository/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/app/guttokback/group/repository/GroupMemberRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.app.guttokback.group.repository;
+
+import com.app.guttokback.group.domain.GroupMemberEntity;
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.Subscription;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class GroupMemberRepositoryTest {
+
+    @Autowired
+    private GroupMemberRepository groupMemberRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SubscriptionGroupRepository subscriptionGroupRepository;
+
+    @AfterEach
+    public void clear() {
+        groupMemberRepository.deleteAllInBatch();
+        subscriptionGroupRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    private UserEntity createUser(String email) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private SubscriptionGroupEntity createSubscriptionGroup(UserEntity user) {
+        SubscriptionGroupEntity subscriptionGroupEntity = SubscriptionGroupEntity.builder()
+                .user(user)
+                .title("test")
+                .subscription(Subscription.CUSTOM_INPUT)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .notice("test")
+                .build();
+        return subscriptionGroupRepository.save(subscriptionGroupEntity);
+    }
+
+    @Test
+    @DisplayName("group_members 테이블에 매핑된 그룹 멤버가 존재하면 true를 반환한다.")
+    public void existsByUserAndSubscriptionGroupIsTrueTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+        SubscriptionGroupEntity subscriptionGroup = createSubscriptionGroup(user);
+
+        GroupMemberEntity groupMemberEntity = GroupMemberEntity.builder()
+                .user(user)
+                .subscriptionGroup(subscriptionGroup)
+                .build();
+        groupMemberRepository.save(groupMemberEntity);
+
+        // when
+        boolean exists = groupMemberRepository.existsByUserAndSubscriptionGroup(user, subscriptionGroup);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("group_members 테이블에 매핑된 그룹 멤버가 존재하지않으면 false를 반환한다.")
+    public void existsByUserAndSubscriptionGroupIsFalseTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+        SubscriptionGroupEntity subscriptionGroup = createSubscriptionGroup(user);
+
+        // when
+        boolean exists = groupMemberRepository.existsByUserAndSubscriptionGroup(user, subscriptionGroup);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+}

--- a/src/test/java/com/app/guttokback/group/service/GroupMemberServiceTest.java
+++ b/src/test/java/com/app/guttokback/group/service/GroupMemberServiceTest.java
@@ -1,0 +1,100 @@
+package com.app.guttokback.group.service;
+
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.group.domain.GroupMemberEntity;
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.group.repository.GroupMemberRepository;
+import com.app.guttokback.group.repository.SubscriptionGroupRepository;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.Subscription;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class GroupMemberServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SubscriptionGroupRepository subscriptionGroupRepository;
+    @Autowired
+    private GroupMemberRepository groupMemberRepository;
+    @Autowired
+    private GroupMemberService groupMemberService;
+
+    @AfterEach
+    public void clear() {
+        groupMemberRepository.deleteAllInBatch();
+        subscriptionGroupRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    private UserEntity createUser(String email) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private SubscriptionGroupEntity createSubscriptionGroup(UserEntity user) {
+        SubscriptionGroupEntity subscriptionGroupEntity = SubscriptionGroupEntity.builder()
+                .user(user)
+                .title("test")
+                .subscription(Subscription.CUSTOM_INPUT)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .notice("test")
+                .build();
+        return subscriptionGroupRepository.save(subscriptionGroupEntity);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("그룹과 유저정보가 매핑되어 정상적으로 저장된다.")
+    public void addMemberTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+        SubscriptionGroupEntity subscriptionGroup = createSubscriptionGroup(user);
+
+        // when
+        groupMemberService.addMember(user, subscriptionGroup);
+
+        // then
+        GroupMemberEntity groupMember = groupMemberRepository.findAll().getFirst();
+        assertThat(groupMember.getUser()).isEqualTo(user);
+        assertThat(groupMember.getSubscriptionGroup()).isEqualTo(subscriptionGroup);
+    }
+
+    @Test
+    @DisplayName("이미 참가한 그룹에 참가 시도 시 예외가 발생한다.")
+    public void addMemberByValidateJoinGroupTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+        SubscriptionGroupEntity subscriptionGroup = createSubscriptionGroup(user);
+        groupMemberService.addMember(user, subscriptionGroup);
+
+        // when
+        CustomApplicationException exception = assertThrows(CustomApplicationException.class,
+                () -> groupMemberService.addMember(user, subscriptionGroup));
+
+        // then
+        assertThat(exception)
+                .isInstanceOf(CustomApplicationException.class)
+                .hasMessage("이미 참가한 그룹입니다.");
+    }
+
+}

--- a/src/test/java/com/app/guttokback/group/service/SubscriptionGroupServiceTest.java
+++ b/src/test/java/com/app/guttokback/group/service/SubscriptionGroupServiceTest.java
@@ -1,0 +1,106 @@
+package com.app.guttokback.group.service;
+
+import com.app.guttokback.global.exception.CustomApplicationException;
+import com.app.guttokback.group.domain.SubscriptionGroupEntity;
+import com.app.guttokback.group.dto.serviceDto.SubscriptionGroupSaveInfo;
+import com.app.guttokback.group.repository.GroupMemberRepository;
+import com.app.guttokback.group.repository.SubscriptionGroupRepository;
+import com.app.guttokback.subscription.domain.PaymentCycle;
+import com.app.guttokback.subscription.domain.PaymentMethod;
+import com.app.guttokback.subscription.domain.Subscription;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class SubscriptionGroupServiceTest {
+
+    @Autowired
+    private SubscriptionGroupService subscriptionGroupService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SubscriptionGroupRepository subscriptionGroupRepository;
+    @Autowired
+    private GroupMemberRepository groupMemberRepository;
+
+    @AfterEach
+    public void clear() {
+        groupMemberRepository.deleteAllInBatch();
+        subscriptionGroupRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    private UserEntity createUser(String email) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        return userRepository.save(user);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("존재하는 회원이 그룹 생성 시 해당회원을 생성자로하여 그룹이 정상적으로 생성된다.")
+    public void savedSubscriptionGroupTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+
+        SubscriptionGroupSaveInfo subscriptionGroupSaveInfo = SubscriptionGroupSaveInfo.builder()
+                .email(user.getEmail())
+                .title("test")
+                .subscription(Subscription.CUSTOM_INPUT)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .notice("test")
+                .build();
+
+        // when
+        subscriptionGroupService.save(subscriptionGroupSaveInfo);
+
+        // then
+        SubscriptionGroupEntity subscriptionGroup = subscriptionGroupRepository.findAll().getFirst();
+        assertThat(subscriptionGroup.getUser().getEmail()).isEqualTo(subscriptionGroupSaveInfo.getEmail());
+        assertThat(subscriptionGroup.getTitle()).isEqualTo(subscriptionGroupSaveInfo.getTitle());
+        assertThat(subscriptionGroup.getSubscription()).isEqualTo(subscriptionGroupSaveInfo.getSubscription());
+        assertThat(subscriptionGroup.getPaymentAmount()).isEqualTo(subscriptionGroupSaveInfo.getPaymentAmount());
+        assertThat(subscriptionGroup.getPaymentMethod()).isEqualTo(subscriptionGroupSaveInfo.getPaymentMethod());
+        assertThat(subscriptionGroup.getPaymentCycle()).isEqualTo(subscriptionGroupSaveInfo.getPaymentCycle());
+        assertThat(subscriptionGroup.getNotice()).isEqualTo(subscriptionGroupSaveInfo.getNotice());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이 그룹 생성 시 예외가 발생한다.")
+    public void savedSubscriptionGroupByValidateUserTest() {
+        // given
+        SubscriptionGroupSaveInfo subscriptionGroupSaveInfo = SubscriptionGroupSaveInfo.builder()
+                .email(null)
+                .title("test")
+                .subscription(Subscription.CUSTOM_INPUT)
+                .paymentAmount(10000)
+                .paymentMethod(PaymentMethod.CARD)
+                .paymentCycle(PaymentCycle.MONTHLY)
+                .notice("test")
+                .build();
+
+        // when
+        CustomApplicationException exception = assertThrows(CustomApplicationException.class,
+                () -> subscriptionGroupService.save(subscriptionGroupSaveInfo));
+
+        // then
+        assertThat(exception)
+                .isInstanceOf(CustomApplicationException.class)
+                .hasMessage("계정을 찾을 수 없습니다");
+    }
+}


### PR DESCRIPTION
[POST] /api/groups

#### 기능 구현
- **그룹 생성 API** 구현
  - 그룹 생성 시 `title` (그룹 명)은 필수 입력값으로 처리
  - 그룹 생성 시 생성자 (유저) 정보를 그룹장으로 저장
  - 그룹 생성 후 `group_members` 테이블에 그룹과 유저 정보 매핑
  - 예외 처리
    - 필수 값 미입력 시 `400 Bad Request`
    - 비로그인 시
    - 회원을 찾을 수 없을 시 `404 Not Found`
    - 이미 참가한 그룹에 참가 시 `409 Conflict`

#### 주요 로직
- 그룹 생성 시 `SubscriptionGroupEntity`와 `GroupMemberEntity`를 생성하여, 그룹과 유저 정보를 DB에 저장
- 유효성 검사를 통해 필수 값을 체크하고, 중복 참가를 방지
- 그룹 생성 후, `group_members` 테이블에 유저와 그룹을 매핑하여 저장
- 일반 구독항목 생성과는 별개로 `title(그룹명), subscription(구독서비스)`필수 입력

#### 테스트:
- 예외 처리에 대한 테스트 코드 추가
  - 필수 값 미입력 시, 회원 미존재 시, 중복 참가 시에 대한 검증
- 정상적인 그룹 생성 및 매핑 여부를 확인하는 테스트 코드 작성

### RequestBody
```json
{
    "title": "테스트 그룹",
    "subscription": "YOUTUBE_PREMIUM",
    "paymentAmount": 10000,
    "paymentMethod": "BANK_TRANSFER",
    "paymentCycle": "MONTHLY",
    "paymentDay": 20,
    "notice": "공지입니다."
}
```

### ResponseBody
```json
{
    "message": "그룹 생성 성공",
    "data": null,
    "status": "OK"
}
```