### PR TITLE
GUTTOK-71 : ExceptionHandler 추가

### DIFF
--- a/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/global/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
     OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다"),
 
     // group
-    MEMBER_ALREADY_JOINED_GROUP(HttpStatus.CONFLICT, "GROUP_02", "이미 참가한 그룹입니다.");
+    MEMBER_ALREADY_JOINED_GROUP(HttpStatus.CONFLICT, "GROUP_02", "이미 참가한 그룹입니다."),
+
+    // json
+    INVALID_JSON_INPUT(HttpStatus.BAD_REQUEST, "JSON_ERROR", "%s 필드 값이 잘못되었습니다. [%s] 타입이어야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,27 @@
 package com.app.guttokback.global.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.Objects;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<CustomExceptionResponse> responseBindException(BindException exception) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        return new ResponseEntity<>(
+                new CustomExceptionResponse(httpStatus, "BAD_REQUEST_ERROR", Objects.requireNonNull(exception.getFieldError()).getDefaultMessage()),
+                httpStatus
+        );
+    }
 
     @ExceptionHandler(CustomApplicationException.class)
     public ResponseEntity<CustomExceptionResponse> handleCustomApplicationException(CustomApplicationException exception) {
@@ -15,5 +31,32 @@ public class GlobalExceptionHandler {
                 exception.getErrorCode().getMessage()
         );
         return new ResponseEntity<>(errorResponse, exception.getErrorCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CustomExceptionResponse> requestHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
+        InvalidFormatException invalidFormatException = (InvalidFormatException) exception.getCause();
+        String fieldName = invalidFormatException.getPath().getFirst().getFieldName();
+        String targetType = invalidFormatException.getTargetType().getSimpleName();
+
+        String errorMessage = String.format(ErrorCode.INVALID_JSON_INPUT.getMessage(), fieldName, targetType);
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+        return new ResponseEntity<>(
+                new CustomExceptionResponse(httpStatus, ErrorCode.INVALID_JSON_INPUT.getErrorCode(), Objects.requireNonNull(errorMessage)), httpStatus);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<CustomExceptionResponse> responseNoResourceFoundException() {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+        CustomExceptionResponse errorResult = new CustomExceptionResponse(httpStatus, "ENDPOINT_ERROR", "잘못된 요청입니다.");
+        return new ResponseEntity<>(errorResult, httpStatus);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomExceptionResponse> responseException() {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        CustomExceptionResponse errorResponse = new CustomExceptionResponse(httpStatus, "SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+        return new ResponseEntity<>(errorResponse, httpStatus);
     }
 }


### PR DESCRIPTION
바인드 에러, json 에러, 엔드포인트 에러, 서버에러에 대한 ExceptionHandler 추가하였습니다.

```json
// bind error

{
    "errorCode": "BAD_REQUEST_ERROR",
    "message": "결제일자는 1 이상이어야 합니다.",
    "code": 400
}
```

```json
// json error

{
    "errorCode": "JSON_ERROR",
    "message": "paymentDay 필드 값이 잘못되었습니다. [int] 타입이어야 합니다.",
    "code": 400
}
```

```json
// endpoint error

{
    "errorCode": "ENDPOINT_ERROR",
    "message": "잘못된 요청입니다.",
    "code": 404
}
```

```json
// server error

{
    "errorCode": "SERVER_ERROR",
    "message": "서버 내부 오류가 발생했습니다.",
    "code": 500
}
```