### PR TITLE
Guttok 76 : 알림 조회 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/util/PageOption.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/util/PageOption.java
@@ -1,9 +1,9 @@
-package com.app.guttokback.subscription.dto.serviceDto;
+package com.app.guttokback.global.apiResponse.util;
 
 import lombok.Getter;
 
 @Getter
-public class UserSubscriptionListInfo {
+public class PageOption {
 
     private final String userEmail;
 
@@ -11,7 +11,7 @@ public class UserSubscriptionListInfo {
 
     private final long size;
 
-    public UserSubscriptionListInfo(String userEmail, Long lastId, long size) {
+    public PageOption(String userEmail, Long lastId, long size) {
         this.userEmail = userEmail;
         this.lastId = lastId;
         this.size = size;

--- a/src/main/java/com/app/guttokback/global/apiResponse/util/PageRequest.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/util/PageRequest.java
@@ -1,6 +1,5 @@
-package com.app.guttokback.subscription.dto.controllerDto.request;
+package com.app.guttokback.global.apiResponse.util;
 
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
 import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserSubscriptionListRequest {
+public class PageRequest {
 
     @Positive(message = "데이터의 id는 양수여야 합니다.")
     private Long lastId;
@@ -16,12 +15,12 @@ public class UserSubscriptionListRequest {
     @Positive(message = "한 페이지에 조회 할 데이터 수는 양수여야 합니다.")
     private long size;
 
-    public UserSubscriptionListRequest(Long lastId, Long size) {
+    public PageRequest(Long lastId, Long size) {
         this.lastId = lastId;
         this.size = size == null ? 10L : size;
     }
 
-    public UserSubscriptionListInfo toListOption(String userEmail) {
-        return new UserSubscriptionListInfo(userEmail, lastId, size);
+    public PageOption toListOption(String userEmail) {
+        return new PageOption(userEmail, lastId, size);
     }
 }

--- a/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
+++ b/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notifications")
-public class notificationController {
+public class NotificationController {
 
     private final NotificationService notificationService;
 

--- a/src/main/java/com/app/guttokback/notification/controller/notificationController.java
+++ b/src/main/java/com/app/guttokback/notification/controller/notificationController.java
@@ -1,0 +1,29 @@
+package com.app.guttokback.notification.controller;
+
+import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageRequest;
+import com.app.guttokback.notification.dto.controllerDto.response.NotificationListResponse;
+import com.app.guttokback.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class notificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public PageResponse<NotificationListResponse> notificationList(
+            @Valid PageRequest pageRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return notificationService.list(pageRequest.toListOption(userDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/app/guttokback/notification/dto/controllerDto/response/NotificationListResponse.java
+++ b/src/main/java/com/app/guttokback/notification/dto/controllerDto/response/NotificationListResponse.java
@@ -1,0 +1,58 @@
+package com.app.guttokback.notification.dto.controllerDto.response;
+
+import com.app.guttokback.notification.domain.Category;
+import com.app.guttokback.notification.domain.NotificationEntity;
+import com.app.guttokback.notification.domain.Status;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationListResponse {
+
+    private Long id;
+
+    private Category category;
+
+    private String message;
+
+    private Status status;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime registerDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime updateDate;
+
+    @Builder
+    public NotificationListResponse(Long id,
+                                    Category category,
+                                    String message,
+                                    Status status,
+                                    LocalDateTime registerDate,
+                                    LocalDateTime updateDate
+    ) {
+        this.id = id;
+        this.category = category;
+        this.message = message;
+        this.status = status;
+        this.registerDate = registerDate;
+        this.updateDate = updateDate;
+    }
+
+    public static NotificationListResponse of(NotificationEntity notification) {
+        return NotificationListResponse.builder()
+                .id(notification.getId())
+                .category(notification.getCategory())
+                .message(notification.getMessage())
+                .status(notification.getStatus())
+                .registerDate(notification.getRegisterDate())
+                .updateDate(notification.getUpdateDate())
+                .build();
+    }
+}

--- a/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
@@ -1,0 +1,36 @@
+package com.app.guttokback.notification.repository;
+
+import com.app.guttokback.global.apiResponse.util.PageOption;
+import com.app.guttokback.notification.domain.NotificationEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.app.guttokback.notification.domain.QNotificationEntity.notificationEntity;
+import static com.app.guttokback.user.domain.QUserEntity.userEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<NotificationEntity> findPageNotifications(PageOption pageOption) {
+        return jpaQueryFactory
+                .selectFrom(notificationEntity)
+                .innerJoin(notificationEntity.user, userEntity)
+                .fetchJoin()
+                .where(userEntity.email.eq(pageOption.getUserEmail())
+                        .and(lastIdCondition(pageOption.getLastId())))
+                .orderBy(notificationEntity.id.desc())
+                .limit(pageOption.getSize() + 1)
+                .fetch();
+    }
+
+    private BooleanExpression lastIdCondition(Long lastId) {
+        return lastId != null ? notificationEntity.id.lt(lastId) : null;
+    }
+}

--- a/src/main/java/com/app/guttokback/notification/service/NotificationService.java
+++ b/src/main/java/com/app/guttokback/notification/service/NotificationService.java
@@ -1,9 +1,13 @@
 package com.app.guttokback.notification.service;
 
+import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.notification.domain.Category;
 import com.app.guttokback.notification.domain.Message;
 import com.app.guttokback.notification.domain.NotificationEntity;
 import com.app.guttokback.notification.domain.Status;
+import com.app.guttokback.notification.dto.controllerDto.response.NotificationListResponse;
+import com.app.guttokback.notification.repository.NotificationQueryRepository;
 import com.app.guttokback.notification.repository.NotificationRepository;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
@@ -12,12 +16,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationQueryRepository notificationQueryRepository;
 
     @Transactional
     public void userSaveNotification(UserEntity userEntity) {
@@ -46,5 +53,23 @@ public class NotificationService {
                 .message(message)
                 .status(Status.UNREAD)
                 .build());
+    }
+
+    public PageResponse<NotificationListResponse> list(PageOption pageOption) {
+        List<NotificationEntity> notifications = notificationQueryRepository.findPageNotifications(pageOption);
+
+        boolean hasNext = notifications.size() > pageOption.getSize();
+
+        List<NotificationEntity> pagedNotifications = notifications.stream()
+                .limit(pageOption.getSize())
+                .toList();
+
+        return PageResponse
+                .of(pagedNotifications.stream()
+                                .map(NotificationListResponse::of)
+                                .toList(),
+                        pageOption.getSize(),
+                        hasNext
+                );
     }
 }

--- a/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/app/guttokback/subscription/controller/UserSubscriptionController.java
@@ -2,8 +2,8 @@ package com.app.guttokback.subscription.controller;
 
 import com.app.guttokback.global.apiResponse.ApiResponse;
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.SubscriptionSearchRequest;
-import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
@@ -38,10 +38,10 @@ public class UserSubscriptionController {
 
     @GetMapping("/user")
     public PageResponse<UserSubscriptionListResponse> userSubscriptionList(
-            @Valid UserSubscriptionListRequest userSubscriptionListRequest,
+            @Valid PageRequest pageRequest,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        return userSubscriptionService.list(userSubscriptionListRequest.toListOption(userDetails.getUsername()));
+        return userSubscriptionService.list(pageRequest.toListOption(userDetails.getUsername()));
     }
 
     @PatchMapping("/{userSubscriptionId}")

--- a/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepository.java
+++ b/src/main/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepository.java
@@ -1,7 +1,7 @@
 package com.app.guttokback.subscription.repository;
 
+import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +20,12 @@ public class UserSubscriptionQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     // UserSubscription 리스트 페이징 조회 쿼리
-    public List<UserSubscriptionEntity> findPagedUserSubscriptions(UserSubscriptionListInfo userSubscriptionListInfo) {
+    public List<UserSubscriptionEntity> findPagedUserSubscriptions(PageOption pageOption) {
         return jpaQueryFactory
                 .selectFrom(userSubscriptionEntity)
-                .where(lastIdCondition(userSubscriptionListInfo.getLastId()))
+                .where(lastIdCondition(pageOption.getLastId()))
                 .orderBy(userSubscriptionEntity.id.desc())
-                .limit(userSubscriptionListInfo.getSize() + 1)
+                .limit(pageOption.getSize() + 1)
                 .fetch();
     }
 

--- a/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
+++ b/src/main/java/com/app/guttokback/subscription/service/UserSubscriptionService.java
@@ -1,6 +1,7 @@
 package com.app.guttokback.subscription.service;
 
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.global.aws.ses.service.ReminderService;
 import com.app.guttokback.global.exception.CustomApplicationException;
 import com.app.guttokback.global.exception.ErrorCode;
@@ -8,7 +9,10 @@ import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.*;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionSearchInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
 import com.app.guttokback.subscription.repository.UserSubscriptionQueryRepository;
 import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
 import com.app.guttokback.user.domain.UserEntity;
@@ -53,23 +57,23 @@ public class UserSubscriptionService {
         userSubscriptionRepository.save(userSubscriptionEntity);
     }
 
-    public PageResponse<UserSubscriptionListResponse> list(UserSubscriptionListInfo userSubscriptionListInfo) {
-        userService.findByUserEmail(userSubscriptionListInfo.getUserEmail());
+    public PageResponse<UserSubscriptionListResponse> list(PageOption pageOption) {
+        userService.findByUserEmail(pageOption.getUserEmail());
 
         List<UserSubscriptionEntity> userSubscriptions = userSubscriptionQueryRepository
-                .findPagedUserSubscriptions(userSubscriptionListInfo);
+                .findPagedUserSubscriptions(pageOption);
 
-        boolean hasNext = userSubscriptions.size() > userSubscriptionListInfo.getSize();
+        boolean hasNext = userSubscriptions.size() > pageOption.getSize();
 
         List<UserSubscriptionEntity> pagedSubscriptions = userSubscriptions.stream()
-                .limit(userSubscriptionListInfo.getSize())
+                .limit(pageOption.getSize())
                 .toList();
 
         return PageResponse
                 .of(pagedSubscriptions.stream()
                                 .map(UserSubscriptionListResponse::of)
                                 .toList(),
-                        userSubscriptionListInfo.getSize(),
+                        pageOption.getSize(),
                         hasNext
                 );
     }

--- a/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,70 @@
+package com.app.guttokback.notification.controller;
+
+import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageOption;
+import com.app.guttokback.global.apiResponse.util.PageRequest;
+import com.app.guttokback.notification.domain.Category;
+import com.app.guttokback.notification.domain.Status;
+import com.app.guttokback.notification.dto.controllerDto.response.NotificationListResponse;
+import com.app.guttokback.notification.service.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@WithMockUser
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private NotificationService notificationService;
+
+    private final Long testId = 1L;
+
+    @Test
+    public void NotificationListTest() throws Exception {
+        // given
+        PageRequest pageRequest = new PageRequest(testId, 1L);
+
+        NotificationListResponse mockResponse = NotificationListResponse.builder()
+                .id(testId)
+                .category(Category.APPLICATION)
+                .message("test")
+                .status(Status.UNREAD)
+                .build();
+
+        when(notificationService.list(any(PageOption.class)))
+                .thenReturn(PageResponse.of(Collections.singletonList(mockResponse), 1L, false));
+
+        // when & then
+        mockMvc.perform(get("/api/notifications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(pageRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contents").isNotEmpty())
+                .andExpect(jsonPath("$.size").value(1))
+                .andExpect(jsonPath("$.hasNext").value(false));
+
+        verify(notificationService).list(any(PageOption.class));
+    }
+
+}

--- a/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
+++ b/src/test/java/com/app/guttokback/subscription/controller/UserSubscriptionControllerTest.java
@@ -2,15 +2,19 @@ package com.app.guttokback.subscription.controller;
 
 import com.app.guttokback.global.apiResponse.PageResponse;
 import com.app.guttokback.global.apiResponse.ResponseMessages;
+import com.app.guttokback.global.apiResponse.util.PageOption;
+import com.app.guttokback.global.apiResponse.util.PageRequest;
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
 import com.app.guttokback.subscription.domain.PaymentStatus;
 import com.app.guttokback.subscription.domain.Subscription;
-import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionListRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionSaveRequest;
 import com.app.guttokback.subscription.dto.controllerDto.request.UserSubscriptionUpdateRequest;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.*;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionSearchInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
 import com.app.guttokback.subscription.service.UserSubscriptionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -77,7 +81,7 @@ class UserSubscriptionControllerTest {
     @DisplayName("사용자 구독정보 조회 시 요청 데이터가 성공 응답을 반환한다.")
     public void userSubscriptionListTest() throws Exception {
         // given
-        UserSubscriptionListRequest listRequest = new UserSubscriptionListRequest(testId, 1L);
+        PageRequest listRequest = new PageRequest(testId, 1L);
 
         UserSubscriptionListResponse mockResponse = UserSubscriptionListResponse.builder()
                 .title("test")
@@ -87,7 +91,7 @@ class UserSubscriptionControllerTest {
                 .paymentDay(1)
                 .build();
 
-        when(userSubscriptionService.list(any(UserSubscriptionListInfo.class)))
+        when(userSubscriptionService.list(any(PageOption.class)))
                 .thenReturn(PageResponse.of(Collections.singletonList(mockResponse), 1L, false));
 
         // when & then
@@ -100,7 +104,7 @@ class UserSubscriptionControllerTest {
                 .andExpect(jsonPath("$.size").value(1))
                 .andExpect(jsonPath("$.hasNext").value(false));
 
-        verify(userSubscriptionService).list(any(UserSubscriptionListInfo.class));
+        verify(userSubscriptionService).list(any(PageOption.class));
     }
 
     @Test

--- a/src/test/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepositoryTest.java
+++ b/src/test/java/com/app/guttokback/subscription/repository/UserSubscriptionQueryRepositoryTest.java
@@ -1,11 +1,11 @@
 package com.app.guttokback.subscription.repository;
 
+import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.global.queryDsl.QueryDslConfig;
 import com.app.guttokback.subscription.domain.PaymentCycle;
 import com.app.guttokback.subscription.domain.PaymentMethod;
 import com.app.guttokback.subscription.domain.Subscription;
 import com.app.guttokback.subscription.domain.UserSubscriptionEntity;
-import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionListInfo;
 import com.app.guttokback.user.domain.UserEntity;
 import com.app.guttokback.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -64,13 +64,13 @@ class UserSubscriptionQueryRepositoryTest {
                 .build();
         UserSubscriptionEntity savedUserSubscription = userSubscriptionRepository.save(userSubscription);
 
-        UserSubscriptionListInfo userSubscriptionListInfo = new UserSubscriptionListInfo(
+        PageOption pageOption = new PageOption(
                 null, null, 5
         );
 
         // when
         List<UserSubscriptionEntity> list
-                = userSubscriptionQueryRepository.findPagedUserSubscriptions(userSubscriptionListInfo);
+                = userSubscriptionQueryRepository.findPagedUserSubscriptions(pageOption);
 
         // then
         assertThat(list).hasSize(1);

--- a/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/com/app/guttokback/subscription/service/UserSubscriptionServiceTest.java
@@ -1,10 +1,14 @@
 package com.app.guttokback.subscription.service;
 
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.global.exception.CustomApplicationException;
 import com.app.guttokback.subscription.domain.*;
 import com.app.guttokback.subscription.dto.controllerDto.response.UserSubscriptionListResponse;
-import com.app.guttokback.subscription.dto.serviceDto.*;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionListInfo;
+import com.app.guttokback.subscription.dto.serviceDto.SubscriptionSearchInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionSaveInfo;
+import com.app.guttokback.subscription.dto.serviceDto.UserSubscriptionUpdateInfo;
 import com.app.guttokback.subscription.repository.UserSubscriptionRepository;
 import com.app.guttokback.user.domain.UserEntity;
 import com.app.guttokback.user.repository.UserRepository;
@@ -135,12 +139,12 @@ class UserSubscriptionServiceTest {
                 .build();
         UserSubscriptionEntity savedUserSubscription = userSubscriptionRepository.save(userSubscription);
 
-        UserSubscriptionListInfo userSubscriptionListInfo = new UserSubscriptionListInfo(
+        PageOption pageOption = new PageOption(
                 savedUser.getEmail(), null, 5
         );
 
         // when
-        PageResponse<UserSubscriptionListResponse> list = userSubscriptionService.list(userSubscriptionListInfo);
+        PageResponse<UserSubscriptionListResponse> list = userSubscriptionService.list(pageOption);
 
         // then
         assertThat(list.getContents())


### PR DESCRIPTION
[GET] /api/notifications?lastId=1&size=10

- 사이즈 요청 가능 default size = 10
- lastId(notificationId)는 nullable할 수 있다.
- lastId 기준 내림차순
- lastId 기준 다음에 보여줄 데이터 없을 시 hasNext = false

## ResponseBody
```json
{
    "contents": [
        {
            "id": 5,
            "category": "REMINDER",
            "message": "구똑님, 내일은 테스트 결제일 입니다 💰",
            "status": "UNREAD",
            "registerDate": "2025-02-04 19:06:44",
            "updateDate": "2025-02-04 19:06:44"
        },
        {
            "id": 4,
            "category": "REMINDER",
            "message": "구똑님, 내일은 유튜브 프리미엄 결제일 입니다 💰",
            "status": "UNREAD",
            "registerDate": "2025-02-04 19:06:44",
            "updateDate": "2025-02-04 19:06:44"
        }
    ],
    "size": 10,
    "hasNext": false
}
```