### PR TITLE
Guttok 78 : 알림 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -27,4 +27,7 @@ public class ResponseMessages {
 
     // group
     public static final String SUBSCRIPTION_GROUP_SAVE_SUCCESS = "그룹 생성 성공";
+
+    // notification
+    public static final String NOTIFICATION_READ_SUCCESS = "알림 읽음 처리 성공";
 }

--- a/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/app/guttokback/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.app.guttokback.global.exception;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -11,12 +12,14 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Objects;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BindException.class)
     public ResponseEntity<CustomExceptionResponse> responseBindException(BindException exception) {
         HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        log.info(exception.getMessage(), exception);
         return new ResponseEntity<>(
                 new CustomExceptionResponse(httpStatus, "BAD_REQUEST_ERROR", Objects.requireNonNull(exception.getFieldError()).getDefaultMessage()),
                 httpStatus
@@ -30,6 +33,7 @@ public class GlobalExceptionHandler {
                 exception.getErrorCode().getErrorCode(),
                 exception.getErrorCode().getMessage()
         );
+        log.info(exception.getMessage(), exception);
         return new ResponseEntity<>(errorResponse, exception.getErrorCode().getHttpStatus());
     }
 
@@ -42,21 +46,24 @@ public class GlobalExceptionHandler {
         String errorMessage = String.format(ErrorCode.INVALID_JSON_INPUT.getMessage(), fieldName, targetType);
         HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
 
+        log.info(errorMessage, exception);
         return new ResponseEntity<>(
                 new CustomExceptionResponse(httpStatus, ErrorCode.INVALID_JSON_INPUT.getErrorCode(), Objects.requireNonNull(errorMessage)), httpStatus);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<CustomExceptionResponse> responseNoResourceFoundException() {
+    public ResponseEntity<CustomExceptionResponse> responseNoResourceFoundException(NoResourceFoundException exception) {
         HttpStatus httpStatus = HttpStatus.NOT_FOUND;
         CustomExceptionResponse errorResult = new CustomExceptionResponse(httpStatus, "ENDPOINT_ERROR", "잘못된 요청입니다.");
+        log.info(exception.getMessage(), exception);
         return new ResponseEntity<>(errorResult, httpStatus);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<CustomExceptionResponse> responseException() {
+    public ResponseEntity<CustomExceptionResponse> responseException(Exception exception) {
         HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         CustomExceptionResponse errorResponse = new CustomExceptionResponse(httpStatus, "SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+        log.error(exception.getMessage(), exception);
         return new ResponseEntity<>(errorResponse, httpStatus);
     }
 }

--- a/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
+++ b/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
@@ -1,14 +1,18 @@
 package com.app.guttokback.notification.controller;
 
+import com.app.guttokback.global.apiResponse.ApiResponse;
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.ResponseMessages;
 import com.app.guttokback.global.apiResponse.util.PageRequest;
 import com.app.guttokback.notification.dto.controllerDto.response.NotificationListResponse;
 import com.app.guttokback.notification.service.NotificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +29,12 @@ public class NotificationController {
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         return notificationService.list(pageRequest.toListOption(userDetails.getUsername()));
+    }
+
+
+    @PutMapping
+    public ResponseEntity<ApiResponse<String>> notificationUpdate(@AuthenticationPrincipal UserDetails userDetails) {
+        notificationService.statusUpdate(userDetails.getUsername());
+        return ApiResponse.success(ResponseMessages.NOTIFICATION_READ_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/notification/domain/NotificationEntity.java
+++ b/src/main/java/com/app/guttokback/notification/domain/NotificationEntity.java
@@ -38,4 +38,8 @@ public class NotificationEntity extends AuditInformation {
         this.message = message;
         this.status = status;
     }
+
+    public void statusUpdate(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
@@ -2,6 +2,7 @@ package com.app.guttokback.notification.repository;
 
 import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.notification.domain.NotificationEntity;
+import com.app.guttokback.notification.domain.Status;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,16 @@ public class NotificationQueryRepository {
                         .and(lastIdCondition(pageOption.getLastId())))
                 .orderBy(notificationEntity.id.desc())
                 .limit(pageOption.getSize() + 1)
+                .fetch();
+    }
+
+    public List<NotificationEntity> findUnReadNotifications(String userEmail) {
+        return jpaQueryFactory
+                .selectFrom(notificationEntity)
+                .innerJoin(notificationEntity.user, userEntity)
+                .fetchJoin()
+                .where(notificationEntity.status.eq(Status.UNREAD)
+                        .and(userEntity.email.eq(userEmail)))
                 .fetch();
     }
 

--- a/src/main/java/com/app/guttokback/notification/service/NotificationService.java
+++ b/src/main/java/com/app/guttokback/notification/service/NotificationService.java
@@ -72,4 +72,10 @@ public class NotificationService {
                         hasNext
                 );
     }
+
+    @Transactional
+    public void statusUpdate(String userEmail) {
+        List<NotificationEntity> unReadNotifications = notificationQueryRepository.findUnReadNotifications(userEmail);
+        unReadNotifications.forEach(notificationEntity -> notificationEntity.statusUpdate(Status.READ));
+    }
 }

--- a/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.app.guttokback.notification.controller;
 
 import com.app.guttokback.global.apiResponse.PageResponse;
+import com.app.guttokback.global.apiResponse.ResponseMessages;
 import com.app.guttokback.global.apiResponse.util.PageOption;
 import com.app.guttokback.global.apiResponse.util.PageRequest;
 import com.app.guttokback.notification.domain.Category;
@@ -8,6 +9,7 @@ import com.app.guttokback.notification.domain.Status;
 import com.app.guttokback.notification.dto.controllerDto.response.NotificationListResponse;
 import com.app.guttokback.notification.service.NotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -38,8 +41,10 @@ class NotificationControllerTest {
     private NotificationService notificationService;
 
     private final Long testId = 1L;
+    private final String testEmail = "test@test.com";
 
     @Test
+    @DisplayName("회원에 대해 생성된 알림 조회 시 정상적으로 응답된다.")
     public void NotificationListTest() throws Exception {
         // given
         PageRequest pageRequest = new PageRequest(testId, 1L);
@@ -65,6 +70,19 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.hasNext").value(false));
 
         verify(notificationService).list(any(PageOption.class));
+    }
+
+    @Test
+    @WithMockUser(username = "test@test.com")
+    @DisplayName("회원에 대해 생성된 알림 읽음 업데이트 시 성공 응답을 반환한다.")
+    public void notificationUpdateTest() throws Exception {
+        mockMvc.perform(put("/api/notifications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.NOTIFICATION_READ_SUCCESS));
+
+        verify(notificationService).statusUpdate(testEmail);
     }
 
 }

--- a/src/test/java/com/app/guttokback/notification/repository/NotificationQueryRepositoryTest.java
+++ b/src/test/java/com/app/guttokback/notification/repository/NotificationQueryRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.app.guttokback.notification.repository;
+
+import com.app.guttokback.global.apiResponse.util.PageOption;
+import com.app.guttokback.global.queryDsl.QueryDslConfig;
+import com.app.guttokback.notification.domain.Category;
+import com.app.guttokback.notification.domain.NotificationEntity;
+import com.app.guttokback.notification.domain.Status;
+import com.app.guttokback.user.domain.UserEntity;
+import com.app.guttokback.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({NotificationQueryRepository.class, QueryDslConfig.class})
+class NotificationQueryRepositoryTest {
+
+
+    @Autowired
+    private NotificationQueryRepository notificationQueryRepository;
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    public void clear() {
+        notificationRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    private UserEntity createUser(String email) {
+        UserEntity user = UserEntity.builder()
+                .email(email)
+                .password("!a1234567890")
+                .nickName("test")
+                .alarm(false)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private NotificationEntity createNotification(UserEntity user) {
+        NotificationEntity notification = new NotificationEntity(
+                user,
+                Category.APPLICATION,
+                "test",
+                Status.UNREAD
+        );
+        return notificationRepository.save(notification);
+    }
+
+    @Test
+    @DisplayName("존재하는 회원에 대해 생성된 알림에 대해 조회된다.")
+    public void findPageNotificationsTest() {
+        // given
+        UserEntity user = createUser("test@test.com");
+        NotificationEntity notification = createNotification(user);
+
+        PageOption pageOption = new PageOption(user.getEmail(), null, 5);
+
+        // when
+        List<NotificationEntity> notifications = notificationQueryRepository.findPageNotifications(pageOption);
+
+        // then
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications).extracting(NotificationEntity::getId).containsExactly(notification.getId());
+        assertThat(notifications).extracting(NotificationEntity::getUser).containsExactly(notification.getUser());
+        assertThat(notifications).extracting(NotificationEntity::getCategory).containsExactly(notification.getCategory());
+        assertThat(notifications).extracting(NotificationEntity::getMessage).containsExactly(notification.getMessage());
+        assertThat(notifications).extracting(NotificationEntity::getStatus).containsExactly(notification.getStatus());
+    }
+
+    @Test
+    @DisplayName("존재하는 회원에 대하 생성된 읽지 않은 알림에 대해 조회된다.")
+    public void findUnReadNotificationsTest() {
+        // given
+        UserEntity user = createUser("test1@test.com");
+        NotificationEntity notification = createNotification(user);
+
+        // when
+        List<NotificationEntity> notifications = notificationQueryRepository.findUnReadNotifications(user.getEmail());
+
+        // then
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications).extracting(NotificationEntity::getId).containsExactly(notification.getId());
+        assertThat(notifications).extracting(NotificationEntity::getUser).containsExactly(notification.getUser());
+        assertThat(notifications).extracting(NotificationEntity::getCategory).containsExactly(notification.getCategory());
+        assertThat(notifications).extracting(NotificationEntity::getMessage).containsExactly(notification.getMessage());
+        assertThat(notifications).extracting(NotificationEntity::getStatus).containsExactly(Status.UNREAD);
+    }
+
+}

--- a/src/test/java/com/app/guttokback/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/app/guttokback/notification/service/NotificationServiceTest.java
@@ -145,4 +145,20 @@ class NotificationServiceTest {
         assertThat(list.getContents()).extracting(NotificationListResponse::getStatus).containsExactly(Status.UNREAD);
     }
 
+    @Test
+    @DisplayName("회원에 대한 알림이 정상적으로 읽음 처리 된다.")
+    public void statusUpdateTest() {
+        // given
+        UserEntity user = createUser("test3@test.com");
+        NotificationEntity savedNotification = createNotification(user);
+
+        // when
+        notificationService.statusUpdate(user.getEmail());
+
+        // then
+        NotificationEntity notification = notificationRepository.findAll().getFirst();
+        assertThat(savedNotification.getStatus()).isNotEqualTo(notification.getStatus());
+        assertThat(notification.getStatus()).isEqualTo(Status.READ);
+    }
+
 }


### PR DESCRIPTION
[PUT] /api/notifications

- 해당 api 요청 시 요청한 회원의 읽지않음(UNREAD)상태의 알림 정보가 읽음(READ) 상태로 벌크 업데이트 적용
- 애플리케이션 로그 확인용으로 ExceptionHandler log 추가하였습니다.