### PR TITLE
Guttok 79 : 알림 삭제 API 구현

### DIFF
--- a/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
+++ b/src/main/java/com/app/guttokback/global/apiResponse/ResponseMessages.java
@@ -30,4 +30,5 @@ public class ResponseMessages {
 
     // notification
     public static final String NOTIFICATION_READ_SUCCESS = "알림 읽음 처리 성공";
+    public static final String NOTIFICATION_DELETE_SUCCESS = "알림 삭제 처리 성공";
 }

--- a/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
+++ b/src/main/java/com/app/guttokback/notification/controller/NotificationController.java
@@ -11,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,10 +28,15 @@ public class NotificationController {
         return notificationService.list(pageRequest.toListOption(userDetails.getUsername()));
     }
 
-
     @PutMapping
     public ResponseEntity<ApiResponse<String>> notificationUpdate(@AuthenticationPrincipal UserDetails userDetails) {
         notificationService.statusUpdate(userDetails.getUsername());
         return ApiResponse.success(ResponseMessages.NOTIFICATION_READ_SUCCESS);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<String>> notificationDelete(@AuthenticationPrincipal UserDetails userDetails) {
+        notificationService.delete(userDetails.getUsername());
+        return ApiResponse.success(ResponseMessages.NOTIFICATION_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/app/guttokback/notification/repository/NotificationQueryRepository.java
@@ -41,6 +41,16 @@ public class NotificationQueryRepository {
                 .fetch();
     }
 
+    public List<NotificationEntity> findReadNotifications(String userEmail) {
+        return jpaQueryFactory
+                .selectFrom(notificationEntity)
+                .innerJoin(notificationEntity.user, userEntity)
+                .fetchJoin()
+                .where(notificationEntity.status.eq(Status.READ)
+                        .and(userEntity.email.eq(userEmail)))
+                .fetch();
+    }
+
     private BooleanExpression lastIdCondition(Long lastId) {
         return lastId != null ? notificationEntity.id.lt(lastId) : null;
     }

--- a/src/main/java/com/app/guttokback/notification/service/NotificationService.java
+++ b/src/main/java/com/app/guttokback/notification/service/NotificationService.java
@@ -78,4 +78,10 @@ public class NotificationService {
         List<NotificationEntity> unReadNotifications = notificationQueryRepository.findUnReadNotifications(userEmail);
         unReadNotifications.forEach(notificationEntity -> notificationEntity.statusUpdate(Status.READ));
     }
+
+    @Transactional
+    public void delete(String userEmail) {
+        List<NotificationEntity> readNotifications = notificationQueryRepository.findReadNotifications(userEmail);
+        notificationRepository.deleteAll(readNotifications);
+    }
 }

--- a/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/app/guttokback/notification/controller/NotificationControllerTest.java
@@ -24,8 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -85,4 +84,16 @@ class NotificationControllerTest {
         verify(notificationService).statusUpdate(testEmail);
     }
 
+    @Test
+    @WithMockUser(username = "test@test.com")
+    @DisplayName("회원에 대해 생성된 알림 읽음 업데이트 시 성공 응답을 반환한다.")
+    public void notificationDeleteTest() throws Exception {
+        mockMvc.perform(delete("/api/notifications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseMessages.NOTIFICATION_DELETE_SUCCESS));
+
+        verify(notificationService).delete(testEmail);
+    }
 }

--- a/src/test/java/com/app/guttokback/notification/repository/NotificationQueryRepositoryTest.java
+++ b/src/test/java/com/app/guttokback/notification/repository/NotificationQueryRepositoryTest.java
@@ -46,12 +46,12 @@ class NotificationQueryRepositoryTest {
         return userRepository.save(user);
     }
 
-    private NotificationEntity createNotification(UserEntity user) {
+    private NotificationEntity createNotification(UserEntity user, Status status) {
         NotificationEntity notification = new NotificationEntity(
                 user,
                 Category.APPLICATION,
                 "test",
-                Status.UNREAD
+                status
         );
         return notificationRepository.save(notification);
     }
@@ -61,7 +61,7 @@ class NotificationQueryRepositoryTest {
     public void findPageNotificationsTest() {
         // given
         UserEntity user = createUser("test@test.com");
-        NotificationEntity notification = createNotification(user);
+        NotificationEntity notification = createNotification(user, Status.UNREAD);
 
         PageOption pageOption = new PageOption(user.getEmail(), null, 5);
 
@@ -82,7 +82,7 @@ class NotificationQueryRepositoryTest {
     public void findUnReadNotificationsTest() {
         // given
         UserEntity user = createUser("test1@test.com");
-        NotificationEntity notification = createNotification(user);
+        NotificationEntity notification = createNotification(user, Status.UNREAD);
 
         // when
         List<NotificationEntity> notifications = notificationQueryRepository.findUnReadNotifications(user.getEmail());
@@ -94,6 +94,24 @@ class NotificationQueryRepositoryTest {
         assertThat(notifications).extracting(NotificationEntity::getCategory).containsExactly(notification.getCategory());
         assertThat(notifications).extracting(NotificationEntity::getMessage).containsExactly(notification.getMessage());
         assertThat(notifications).extracting(NotificationEntity::getStatus).containsExactly(Status.UNREAD);
+    }
+
+    @Test
+    public void findReadNotificationsTest() {
+        // given
+        UserEntity user = createUser("test2@test.com");
+        NotificationEntity notification = createNotification(user, Status.READ);
+
+        // when
+        List<NotificationEntity> notifications = notificationQueryRepository.findReadNotifications(user.getEmail());
+
+        // then
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications).extracting(NotificationEntity::getId).containsExactly(notification.getId());
+        assertThat(notifications).extracting(NotificationEntity::getUser).containsExactly(notification.getUser());
+        assertThat(notifications).extracting(NotificationEntity::getCategory).containsExactly(notification.getCategory());
+        assertThat(notifications).extracting(NotificationEntity::getMessage).containsExactly(notification.getMessage());
+        assertThat(notifications).extracting(NotificationEntity::getStatus).containsExactly(Status.READ);
     }
 
 }

--- a/src/test/java/com/app/guttokback/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/app/guttokback/notification/service/NotificationServiceTest.java
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -66,12 +68,12 @@ class NotificationServiceTest {
         return userSubscriptionRepository.save(userSubscription);
     }
 
-    private NotificationEntity createNotification(UserEntity user) {
+    private NotificationEntity createNotification(UserEntity user, Status status) {
         NotificationEntity notification = new NotificationEntity(
                 user,
                 Category.APPLICATION,
                 "test",
-                Status.UNREAD
+                status
         );
         return notificationRepository.save(notification);
     }
@@ -126,7 +128,7 @@ class NotificationServiceTest {
     public void notificationListTest() {
         // given
         UserEntity user = createUser("test2@test.com");
-        NotificationEntity notification = createNotification(user);
+        NotificationEntity notification = createNotification(user, Status.UNREAD);
 
         PageOption pageOption = new PageOption(
                 user.getEmail(), null, 5
@@ -150,7 +152,7 @@ class NotificationServiceTest {
     public void statusUpdateTest() {
         // given
         UserEntity user = createUser("test3@test.com");
-        NotificationEntity savedNotification = createNotification(user);
+        NotificationEntity savedNotification = createNotification(user, Status.UNREAD);
 
         // when
         notificationService.statusUpdate(user.getEmail());
@@ -159,6 +161,21 @@ class NotificationServiceTest {
         NotificationEntity notification = notificationRepository.findAll().getFirst();
         assertThat(savedNotification.getStatus()).isNotEqualTo(notification.getStatus());
         assertThat(notification.getStatus()).isEqualTo(Status.READ);
+    }
+
+    @Test
+    @DisplayName("회원에 대한 알림이 읽음 처리된 것에 대한 삭제가 정상적으로 처리된다.")
+    public void notificationDeleteTest() {
+        // given
+        UserEntity user = createUser("test4@test.com");
+        createNotification(user, Status.READ);
+
+        // when
+        notificationService.delete(user.getEmail());
+
+        // then
+        List<NotificationEntity> notifications = notificationRepository.findAll();
+        assertThat(notifications).isEmpty();
     }
 
 }


### PR DESCRIPTION
[DELETE] /api/notifications

- 해당 api 요청 시 요청한 회원의 읽음(READ)상태의 알림 정보 벌크 삭제