### PR TITLE
Guttok 80 : Scheduler Shedlock 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     // Spring Data Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Sehdlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.2.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/app/guttokback/GuttokBackApplication.java
+++ b/src/main/java/com/app/guttokback/GuttokBackApplication.java
@@ -2,9 +2,7 @@ package com.app.guttokback;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class GuttokBackApplication {
 

--- a/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
+++ b/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
@@ -2,19 +2,22 @@ package com.app.guttokback.global.scheduler;
 
 import com.app.guttokback.global.aws.ses.service.ReminderService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SchedulerTask {
 
     private final ReminderService reminderService;
-
-//    @Scheduled(zone = "Asia/Seoul", cron = "0 0 9 * * ?") // 타임존 서울, 매일 09시 실행
-//    public void sendReminder() {
-//        reminderService.sendReminder(LocalDate.now());
-//    }
-
+/*
+    @Scheduled(zone = "Asia/Seoul", cron = "0 0 9 * * ?") // 타임존 서울, 매일 09시 실행
+    @SchedulerLock(name = "test", lockAtMostFor = "1h", lockAtLeastFor = "5m")
+    public void sendReminder() {
+        reminderService.sendReminder(LocalDate.now());
+    }
+*/
     /*
      * 애플리케이션 실행 시 주기적인 동작으로 임시 주석처리
      * 테스트 시 주석 해제 후 애플리케이션 실행

--- a/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
+++ b/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
@@ -13,7 +13,7 @@ public class SchedulerTask {
     private final ReminderService reminderService;
 /*
     @Scheduled(zone = "Asia/Seoul", cron = "0 0 9 * * ?") // 타임존 서울, 매일 09시 실행
-    @SchedulerLock(name = "test", lockAtMostFor = "1h", lockAtLeastFor = "5m")
+    @SchedulerLock(name = "reminder", lockAtMostFor = "1h", lockAtLeastFor = "5m")
     public void sendReminder() {
         reminderService.sendReminder(LocalDate.now());
     }

--- a/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
+++ b/src/main/java/com/app/guttokback/global/scheduler/SchedulerTask.java
@@ -2,10 +2,8 @@ package com.app.guttokback.global.scheduler;
 
 import com.app.guttokback.global.aws.ses.service.ReminderService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SchedulerTask {

--- a/src/main/java/com/app/guttokback/global/scheduler/config/SchedulerConfig.java
+++ b/src/main/java/com/app/guttokback/global/scheduler/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package com.app.guttokback.global.scheduler.config;
+
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class SchedulerConfig {
+
+    @Bean
+    public RedisLockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
+        return new RedisLockProvider(redisConnectionFactory);
+    }
+
+}


### PR DESCRIPTION
서비스 확장성을 고려하여 Scale-out 환경에서 Scheduler의 중복 실행을 방지하기 위해 Redis 분산락 기반의 Shedlock을 적용하였습니다.

```java
@SchedulerLock(name = "reminder", lockAtMostFor = "1h", lockAtLeastFor = "5m")
```

`lockAtMostFor`
- 락을 최대 1시간 유지하여, 만약 인스턴스가 비정상적으로 종료되더라도 최소 1시간 동안 다른 인스턴스가 같은 작업을 중복 실행하지 않도록 설정하였습니다.

`lockAtLeastFor`
- 최소 5분 동안 락을 유지하여, 작업이 빨리 끝나더라도 일정 시간 동안은 재실행을 방지하였습니다.

이 설정을 통해 여러 인스턴스가 실행되는 환경에서도 동일한 작업이 중복 수행되지 않도록 하였습니다.