### PR TITLE
GUTTOK-108 : secure: true, sameSite: 'none' 설정 추가

### DIFF
--- a/src/main/java/com/app/guttokback/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/app/guttokback/common/infrastructure/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 
 @Configuration
 @EnableWebSecurity
@@ -55,5 +57,13 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CookieSerializer cookieSerializer() {
+        DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+        serializer.setSameSite("None");
+        serializer.setUseSecureCookie(true);
+        return serializer;
     }
 }


### PR DESCRIPTION
Spring security config에 cookieSerializer를 추가하여 
```
serializer.setSameSite("None");
serializer.setUseSecureCookie(true);
```
설정을 해줬습니다