### PR TITLE
GUTTOK-109 : 인증 실패 시 쿠키 삭제

### DIFF
--- a/src/main/java/com/app/guttokback/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/app/guttokback/common/infrastructure/config/SecurityConfig.java
@@ -16,6 +16,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -44,7 +46,15 @@ public class SecurityConfig {
                         ).hasAnyAuthority(Roles.ROLE_USER.toString())
                         .anyRequest().authenticated()
                 )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            if (request.getSession(false) != null) {
+                                request.getSession(false).invalidate();
+                            }
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                        })
+                );
 
         return http.build();
     }


### PR DESCRIPTION
```
.exceptionHandling(exception -> exception
                        .authenticationEntryPoint((request, response, authException) -> {
                            if (request.getSession(false) != null) {
                                request.getSession(false).invalidate();
                            }
                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                        })
                );
```
securityConfig에 위 코드를 적용해서 인증 실패 시 쿠키를 삭제 할 수 있도록 했습니다

인증 실패 했는데 쿠키가 생성되었던 이유는 "Spring Security 확인 -> 인증 없음 -> 예외 처리 및 인증 흐름 시도 -> SecurityContext 저장 필요로 인해 세션 생성됨" 의 흐름이 발생해 쿠키가 생성됐던 것입니다