### PR TITLE
GUTTOK-113 : AWS 회원 탈퇴 오류 수정

### DIFF
--- a/src/main/java/com/app/guttokback/user/domain/entity/User.java
+++ b/src/main/java/com/app/guttokback/user/domain/entity/User.java
@@ -19,9 +19,9 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "USERS")
+@Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE USERS SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
 @SQLRestriction("deleted = false")
 public class User extends BaseEntity implements UserDetails {
 


### PR DESCRIPTION
```
// user entity 수정 전
@Table(name = "USERS")
@SQLDelete(sql = "UPDATE USERS SET deleted = true WHERE id = ?")
```

```
// user entity 수정 후
@Table(name = "users")
@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
```

aws ec2 운영체제인 우분투에서 대소문자 구문이 된다고 합니다
로컬 환경에서는 구분을 안하고 동작해서 로컬 테스트에서 오류 없이 동작했던것 같습니다.

다른 해결 방법으로는 리눅스의 기본 설정을 바꾸는 방법입니다
```
// 변경 전
lower_case_table_names = 0

// 변경 후
lower_case_table_names = 1
```
리눅스의 기본 설정을 바꾸면 DB 서버 전체에 영향을 줘서, 충돌, 마이그레이션 문제 등 유발 가능성이 크다고 합니다