### PR TITLE
Guttok 118 : 테스트 계정 리마인더 발송 처리

### DIFF
--- a/src/main/java/com/app/guttokback/common/converter/EnumConverter.java
+++ b/src/main/java/com/app/guttokback/common/converter/EnumConverter.java
@@ -1,5 +1,6 @@
 package com.app.guttokback.common.converter;
 
+import com.app.guttokback.email.domain.enums.EmailType;
 import com.app.guttokback.notification.domain.enums.Category;
 import com.app.guttokback.notification.domain.enums.Status;
 import com.app.guttokback.userSubscription.domain.enums.PaymentCycle;
@@ -70,6 +71,13 @@ public class EnumConverter<T extends Enum<T>> implements AttributeConverter<T, S
     public static class StatusConverter extends EnumConverter<Status> {
         public StatusConverter() {
             super(Status.class);
+        }
+    }
+
+    @Converter(autoApply = true)
+    public static class EmailTypeConverter extends EnumConverter<EmailType> {
+        public EmailTypeConverter() {
+            super(EmailType.class);
         }
     }
 }

--- a/src/main/java/com/app/guttokback/email/application/service/EmailLogService.java
+++ b/src/main/java/com/app/guttokback/email/application/service/EmailLogService.java
@@ -1,0 +1,35 @@
+package com.app.guttokback.email.application.service;
+
+import com.app.guttokback.email.domain.entity.EmailLog;
+import com.app.guttokback.email.domain.enums.EmailType;
+import com.app.guttokback.email.domain.repository.EmailLogRepository;
+import com.app.guttokback.user.application.service.UserService;
+import com.app.guttokback.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailLogService {
+
+    private final EmailLogRepository emailLogRepository;
+    private final UserService userService;
+
+    @Transactional
+    public void save(String userEmail, EmailType emailType) {
+        User user = userService.findByUserEmail(userEmail);
+        EmailLog emailLog = emailLogRepository.findByUserAndEmailType(user, emailType);
+        if (emailLog == null) {
+            emailLogRepository.save(EmailLog.builder()
+                    .user(user)
+                    .emailType(emailType)
+                    .count(1)
+                    .build()
+            );
+        } else {
+            emailLog.increaseCount();
+        }
+    }
+}

--- a/src/main/java/com/app/guttokback/email/domain/entity/EmailLog.java
+++ b/src/main/java/com/app/guttokback/email/domain/entity/EmailLog.java
@@ -32,4 +32,8 @@ public class EmailLog extends BaseEntity {
         this.emailType = emailType;
         this.count = count;
     }
+
+    public void increaseCount() {
+        count += 1;
+    }
 }

--- a/src/main/java/com/app/guttokback/email/domain/entity/EmailLog.java
+++ b/src/main/java/com/app/guttokback/email/domain/entity/EmailLog.java
@@ -1,0 +1,35 @@
+package com.app.guttokback.email.domain.entity;
+
+import com.app.guttokback.common.domain.BaseEntity;
+import com.app.guttokback.email.domain.enums.EmailType;
+import com.app.guttokback.user.domain.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "email_logs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailLog extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 50, nullable = false)
+    @Comment("이메일 타입")
+    private EmailType emailType;
+
+    @Column(nullable = false)
+    @Comment("이메일 발송 횟수")
+    private long count;
+
+    @Builder
+    public EmailLog(User user, EmailType emailType, long count) {
+        this.user = user;
+        this.emailType = emailType;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/app/guttokback/email/domain/enums/EmailType.java
+++ b/src/main/java/com/app/guttokback/email/domain/enums/EmailType.java
@@ -1,0 +1,12 @@
+package com.app.guttokback.email.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailType {
+    REMINDER("리마인드");
+
+    private final String type;
+}

--- a/src/main/java/com/app/guttokback/email/domain/repository/EmailLogRepository.java
+++ b/src/main/java/com/app/guttokback/email/domain/repository/EmailLogRepository.java
@@ -1,7 +1,11 @@
 package com.app.guttokback.email.domain.repository;
 
 import com.app.guttokback.email.domain.entity.EmailLog;
+import com.app.guttokback.email.domain.enums.EmailType;
+import com.app.guttokback.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailLogRepository extends JpaRepository<EmailLog, Long> {
+
+    EmailLog findByUserAndEmailType(User user, EmailType emailType);
 }

--- a/src/main/java/com/app/guttokback/email/domain/repository/EmailLogRepository.java
+++ b/src/main/java/com/app/guttokback/email/domain/repository/EmailLogRepository.java
@@ -1,0 +1,7 @@
+package com.app.guttokback.email.domain.repository;
+
+import com.app.guttokback.email.domain.entity.EmailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailLogRepository extends JpaRepository<EmailLog, Long> {
+}

--- a/src/main/java/com/app/guttokback/user/application/service/TestAccountResetService.java
+++ b/src/main/java/com/app/guttokback/user/application/service/TestAccountResetService.java
@@ -1,19 +1,24 @@
 package com.app.guttokback.user.application.service;
 
 import com.app.guttokback.common.security.Roles;
+import com.app.guttokback.notification.application.service.NotificationService;
 import com.app.guttokback.user.domain.entity.User;
 import com.app.guttokback.user.domain.repository.UserRepository;
+import com.app.guttokback.userSubscription.domain.entity.UserSubscription;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TestAccountResetService {
 
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public void resetTestAccounts() {
@@ -22,5 +27,12 @@ public class TestAccountResetService {
         for (User user : testUsers) {
             /*이메일 발송횟수, 구독항목 주기 삭제*/
         }
+    }
+
+    @Transactional
+    public void processTestAccountReminders(User user, List<UserSubscription> userSubscriptions) {
+        userSubscriptions.forEach(subscription -> notificationService.reminderNotification(user, subscription));
+        userSubscriptions.forEach(UserSubscription::updateReminderDate);
+        log.info("[TEST_USER] 이메일 발송 제외 - {}", user.getEmail());
     }
 }


### PR DESCRIPTION
테스트 계정에 대한 리마인더 이메일 발송 처리하였습니다.

- 유저 권한이 ROLE_TEST 일 시
  - 이메일을 발송하지 않음
  - 알림 저장 및 reminderDate 갱신은 기존과 동일하게 수행

- 이메일 발송에 대한 추적 로그 테이블 추가
  - 저장 값 : `id(PK)`, `user_id(FK)`, `email_type`, `count`, `register_date`, `update_date`
  - 최초 이메일 발송 시 count를 1로 저장
  - 이후 동일 유형의 이메일 발송 시 count를 1씩 증가
  - emailType으로 이메일 유형을 관리