### PR TITLE
GUTTOK-119: 테스트 계정 구독항목 주기적 삭제 처리

### DIFF
--- a/src/main/java/com/app/guttokback/common/scheduler/SchedulerTask.java
+++ b/src/main/java/com/app/guttokback/common/scheduler/SchedulerTask.java
@@ -1,7 +1,7 @@
 package com.app.guttokback.common.scheduler;
 
 import com.app.guttokback.email.application.service.ReminderService;
-import com.app.guttokback.user.application.service.TestAccountResetService;
+import com.app.guttokback.user.application.service.TestAccountService;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,17 +14,25 @@ import java.time.LocalDate;
 public class SchedulerTask {
 
     private final ReminderService reminderService;
-    private final TestAccountResetService testAccountResetService;
+    private final TestAccountService testAccountService;
 
-    @Scheduled(zone = "Asia/Seoul", cron = "0 0 9 * * ?") // 타임존 서울, 매일 09시 실행
+    /**
+     * 리마인더 이메일 발송
+     * 매일 09시 실행
+     */
+    @Scheduled(zone = "Asia/Seoul", cron = "0 0 9 * * ?")
     @SchedulerLock(name = "reminder", lockAtMostFor = "1h", lockAtLeastFor = "5m")
     public void sendReminder() {
         reminderService.sendReminder(LocalDate.now());
     }
 
-    @Scheduled(zone = "Asia/Seoul", cron = "0 0 0 * * ?")  // 매일 00시 실행
+    /**
+     * 테스트 계정 처리
+     * 매일 00시 실행
+     */
+    @Scheduled(zone = "Asia/Seoul", cron = "0 0 0 * * ?")
     @SchedulerLock(name = "resetTestAccounts", lockAtMostFor = "1h", lockAtLeastFor = "5m")
     public void resetTestUsers() {
-        testAccountResetService.resetTestAccounts();
+        testAccountService.resetTestAccounts();
     }
 }

--- a/src/main/java/com/app/guttokback/email/application/service/ReminderService.java
+++ b/src/main/java/com/app/guttokback/email/application/service/ReminderService.java
@@ -3,7 +3,7 @@ package com.app.guttokback.email.application.service;
 import com.app.guttokback.common.security.Roles;
 import com.app.guttokback.email.domain.enums.EmailType;
 import com.app.guttokback.notification.application.service.NotificationService;
-import com.app.guttokback.user.application.service.TestAccountResetService;
+import com.app.guttokback.user.application.service.TestAccountService;
 import com.app.guttokback.userSubscription.domain.entity.UserSubscription;
 import com.app.guttokback.userSubscription.domain.enums.PaymentCycle;
 import com.app.guttokback.userSubscription.domain.repository.UserSubscriptionQueryRepository;
@@ -26,7 +26,7 @@ public class ReminderService {
     private final EmailTemplateService emailTemplateService;
     private final NotificationService notificationService;
     private final EmailLogService emailLogService;
-    private final TestAccountResetService testAccountResetService;
+    private final TestAccountService testAccountService;
 
     @Transactional
     public void sendReminder(LocalDate now) {
@@ -37,7 +37,7 @@ public class ReminderService {
                 .forEach((user, userSubscriptions) -> {
                     // 테스트 계정 처리
                     if (user.getRoles().contains(Roles.ROLE_TEST)) {
-                        testAccountResetService.processTestAccountReminders(user, userSubscriptions);
+                        testAccountService.processTestAccountReminders(user, userSubscriptions);
                         return;
                     }
                     // 유저 별 총 금액 연산

--- a/src/main/java/com/app/guttokback/user/application/service/TestAccountService.java
+++ b/src/main/java/com/app/guttokback/user/application/service/TestAccountService.java
@@ -5,6 +5,8 @@ import com.app.guttokback.notification.application.service.NotificationService;
 import com.app.guttokback.user.domain.entity.User;
 import com.app.guttokback.user.domain.repository.UserRepository;
 import com.app.guttokback.userSubscription.domain.entity.UserSubscription;
+import com.app.guttokback.userSubscription.domain.repository.UserSubscriptionQueryRepository;
+import com.app.guttokback.userSubscription.domain.repository.UserSubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,20 +17,33 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class TestAccountResetService {
+public class TestAccountService {
 
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final UserSubscriptionQueryRepository userSubscriptionQueryRepository;
+    private final UserSubscriptionRepository userSubscriptionRepository;
 
+    /**
+     * 테스트 계정 구독항목 삭제
+     */
     @Transactional
     public void resetTestAccounts() {
         List<User> testUsers = userRepository.findTestAccounts(Roles.ROLE_TEST);
 
         for (User user : testUsers) {
-            /*이메일 발송횟수, 구독항목 주기 삭제*/
+            List<UserSubscription> toDelete = userSubscriptionQueryRepository.findSubscriptionsToDeleteForTestUser(user.getId());
+
+            if (!toDelete.isEmpty()) {
+                userSubscriptionRepository.deleteAll(toDelete);
+                log.info("[RESET] 테스트 유저({})의 구독항목 {}개 삭제", user.getEmail(), toDelete.size());
+            }
         }
     }
 
+    /**
+     * 테스트 계정 리마인더 처리
+     */
     @Transactional
     public void processTestAccountReminders(User user, List<UserSubscription> userSubscriptions) {
         userSubscriptions.forEach(subscription -> notificationService.reminderNotification(user, subscription));

--- a/src/main/java/com/app/guttokback/userSubscription/domain/repository/UserSubscriptionQueryRepository.java
+++ b/src/main/java/com/app/guttokback/userSubscription/domain/repository/UserSubscriptionQueryRepository.java
@@ -43,6 +43,16 @@ public class UserSubscriptionQueryRepository {
                 .fetch();
     }
 
+    // 테스트 유저의 구독 항목 중 최신 3개 제외한 나머지를 조회
+    public List<UserSubscription> findSubscriptionsToDeleteForTestUser(Long userId) {
+        return jpaQueryFactory
+                .selectFrom(userSubscription)
+                .where(userSubscription.user.id.eq(userId))
+                .orderBy(userSubscription.registerDate.desc())
+                .offset(3)
+                .fetch();
+    }
+
     private BooleanExpression lastIdCondition(Long lastId) {
         return lastId != null ? userSubscription.id.lt(lastId) : null;
     }


### PR DESCRIPTION
테스트 계정에 대해 매일 00시 저장된 구독항목을 삭제하도록 처리하였습니다.
- 매일 00시  스케줄러 실행
- 가장 최신 항목 3개를 제외한 나머지 벌크 삭제 적용