### PR TITLE
GUTTOK-120 : 로그인 실패 오류 해결

### DIFF
--- a/src/main/java/com/app/guttokback/common/exception/ErrorCode.java
+++ b/src/main/java/com/app/guttokback/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH_05", "이 작업을 수행할 권한이 없습니다."),
     INVALID_SESSION(HttpStatus.UNAUTHORIZED, "AUTH_06", "유효하지 않은 세션입니다."),
     EMAIL_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH_07", "입력된 이메일과 세션 이메일이 일치하지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_08", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     // email
     OVER_REQUEST_COUNT(HttpStatus.TOO_MANY_REQUESTS, "EMAIL_01", "인증코드 요청 횟수를 초과했습니다"),

--- a/src/main/java/com/app/guttokback/user/application/controller/AuthController.java
+++ b/src/main/java/com/app/guttokback/user/application/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.app.guttokback.user.application.controller;
 
 import com.app.guttokback.common.api.ApiResponse;
 import com.app.guttokback.common.api.ResponseMessages;
+import com.app.guttokback.common.exception.CustomApplicationException;
+import com.app.guttokback.common.exception.ErrorCode;
 import com.app.guttokback.user.application.dto.controllerDto.LoginRequest;
 import com.app.guttokback.user.application.dto.controllerDto.UserCertificationNumberRequest;
 import com.app.guttokback.user.application.service.SessionService;
@@ -19,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -50,7 +53,12 @@ public class AuthController {
                 loginRequest.getPassword()
         );
 
-        Authentication authentication = authenticationManager.authenticate(token);
+        Authentication authentication;
+        try {
+            authentication = authenticationManager.authenticate(token);
+        } catch (AuthenticationException ex) {
+            throw new CustomApplicationException(ErrorCode.AUTHENTICATION_FAILED);
+        }
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 


### PR DESCRIPTION
GlobalExceptionHandler에서 responseException에 로그인 실패에서 발생하는 Exception을 잡아서 발생하는 문제였습니다

```
// AuthController.class
Authentication authentication;
        try {
            authentication = authenticationManager.authenticate(token);
        } catch (AuthenticationException ex) {
            throw new CustomApplicationException(ErrorCode.AUTHENTICATION_FAILED);
        }
```
CustomApplicationException을 로그인 실패 시 동작하도록 해서 "아이디 또는 비밀번호가 올바르지 않습니다" 메시지가 동작하도록 했습니다
